### PR TITLE
[App] bottom_bar 구현 완료

### DIFF
--- a/app/lib/src/components/bottom_bar.dart
+++ b/app/lib/src/components/bottom_bar.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatefulWidget {
+  const MyWidget({super.key});
+
+  @override
+  State<MyWidget> createState() => _MyWidgetState();
+}
+
+class _MyWidgetState extends State<MyWidget>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this, initialIndex: 1);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: TabBarView(
+        controller: _tabController,
+        children: [], // 이곳에 페이지들 연결 예정정
+      ),
+      bottomNavigationBar: Container(
+        color: Colors.white,
+        child: TabBar(
+          controller: _tabController,
+          indicatorColor: Colors.black,
+          labelColor: Colors.black,
+          unselectedLabelColor: Colors.grey,
+          tabs: [], // 이곳에 페이지로 연결할 탭(버튼) 구성 예정정
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/src/components/bottom_bar.dart
+++ b/app/lib/src/components/bottom_bar.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:talk_pilot/src/pages/schedule_page.dart';
+import 'package:talk_pilot/src/pages/work_page.dart';
+import 'package:talk_pilot/src/pages/profile_page.dart';
 
-class MyWidget extends StatefulWidget {
-  const MyWidget({super.key});
+class BottomBar extends StatefulWidget {
+  const BottomBar({super.key});
 
   @override
-  State<MyWidget> createState() => _MyWidgetState();
+  State<BottomBar> createState() => _BottomBarState();
 }
 
-class _MyWidgetState extends State<MyWidget>
+class _BottomBarState extends State<BottomBar>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
 
@@ -28,7 +31,7 @@ class _MyWidgetState extends State<MyWidget>
     return Scaffold(
       body: TabBarView(
         controller: _tabController,
-        children: [], // 이곳에 페이지들 연결 예정정
+        children: [const SchedulePage(), WorkPage(), const ProfilePage()],
       ),
       bottomNavigationBar: Container(
         color: Colors.white,
@@ -37,7 +40,14 @@ class _MyWidgetState extends State<MyWidget>
           indicatorColor: Colors.black,
           labelColor: Colors.black,
           unselectedLabelColor: Colors.grey,
-          tabs: [], // 이곳에 페이지로 연결할 탭(버튼) 구성 예정정
+          tabs: [
+            Tab(
+              icon: Icon(Icons.calendar_month_rounded, size: 24),
+              text: "Schedule",
+            ),
+            Tab(icon: Icon(Icons.work_rounded, size: 24), text: "Work"),
+            Tab(icon: Icon(Icons.person_rounded, size: 24), text: "Profile"),
+          ],
         ),
       ),
     );

--- a/app/lib/src/pages/base_page.dart
+++ b/app/lib/src/pages/base_page.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+
 import 'package:talk_pilot/src/pages/login_page.dart';
-import 'package:talk_pilot/src/pages/work_page.dart';
+import 'package:talk_pilot/src/components/bottom_bar.dart';
 
 class BasePage extends StatefulWidget {
   const BasePage({super.key});
@@ -25,7 +26,7 @@ class _BasePageState extends State<BasePage> {
           stream: FirebaseAuth.instance.authStateChanges(),
           builder: (context, snapshot) {
             /// 로그인 여부에 따라 login_page or work_page로 이동
-            return !snapshot.hasData ? const LoginPage() : const WorkPage();
+            return !snapshot.hasData ? const LoginPage() : const BottomBar();
           },
         ),
       ),

--- a/app/lib/src/pages/profile_page.dart
+++ b/app/lib/src/pages/profile_page.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class ProfilePage extends StatefulWidget {
+  const ProfilePage({super.key});
+
+  @override
+  State<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends State<ProfilePage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      // 여기에 프로필 페이지 구성(마이페이지)
+    );
+  }
+}

--- a/app/lib/src/pages/schedule_page.dart
+++ b/app/lib/src/pages/schedule_page.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class SchedulePage extends StatefulWidget {
+  const SchedulePage({super.key});
+
+  @override
+  State<SchedulePage> createState() => _SchedulePageState();
+}
+
+class _SchedulePageState extends State<SchedulePage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      // 여기에 달력으로 발표 일정 표시 예정
+    );
+  }
+}


### PR DESCRIPTION
## 주요 변경 사항
- `TabBar` 기반 하단 탭바 UI 구성 및 각 페이지 연결
- 총 3개의 탭 구성: **Schedule**, **Work**, **Profile**
- 모든 탭에 **Rounded 스타일 아이콘과 텍스트(label)** 추가
- flutter 기본 위젯 `TabBar`와 겹치지 않도록 변경
  - `tab_bar.dart` → `bottom_bar.dart` 로 파일명 변경
  - `TabBar()` → `BottomBar()`로 클래스명 변경
  - components 디렉터리에 위치

---

## 작업 상세
- `TabController`를 활용한 탭 상태 관리 구현
- 각 탭에 대응하는 페이지 연결:
  - `SchedulePage`
  - `WorkPage`
  - `ProfilePage`

---

## 참고
-  `schedule_page.dart`, `profile_page.dart`는 임시 UI 구성 완료 (기본 구조만)

---

## 관련 이슈

Closes #7 
