### PR TITLE
[App] `loginWithKakaoAccount()` redirection 문제 해결

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -33,7 +33,7 @@ android {
 
         // manifestPlaceholders
         manifestPlaceholders["KAKAO_NATIVE_APP_KEY"] =
-            project.findProperty("KAKAO_NATIVE_APP_KEY") as String? ?: ""
+            rootProject.extra["KAKAO_NATIVE_APP_KEY"] as? String ?: ""
     }
 
     buildTypes {

--- a/app/android/app/dotenv.gradle
+++ b/app/android/app/dotenv.gradle
@@ -1,13 +1,19 @@
-def dotenvFile = rootProject.file(".env")
+def dotenvFile = file("../../.env")
 def env = [:]
 
 if (dotenvFile.exists()) {
     dotenvFile.eachLine { line ->
         if (line && line.contains('=')) {
-            def (key, value) = line.split('=')
-            env[key.trim()] = value.trim()
+            def keyValue = line.split('=', 2)
+            def key = keyValue[0].trim()
+            def value = keyValue[1].trim()
+            env[key] = value
         }
     }
+    /// set()을 이용해야지만 kts에서 읽을 수 있음
+    rootProject.ext.set("env", env)
+    rootProject.ext.set("KAKAO_NATIVE_APP_KEY", env["KAKAO_NATIVE_APP_KEY"])
+    // println "[dotenv.gradle] KAKAO_NATIVE_APP_KEY loaded: ${env["KAKAO_NATIVE_APP_KEY"]}"
+} else {
+    println "[dotenv.gradle] .env file not found at ${dotenvFile.path}"
 }
-
-ext.env = env

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
                     android:scheme="kakao${KAKAO_NATIVE_APP_KEY}"
-                    android:host="oauth" />
+                    android:host="kakaolink" />
             </intent-filter>
         </activity>
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -33,17 +33,20 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.8
-  firebase_core: ^3.13.0
-  firebase_auth: ^5.5.2
-  google_sign_in: ^6.3.0
-  flutter_dotenv: ^5.2.1
-  kakao_flutter_sdk_common: ^1.9.7+3
-  kakao_flutter_sdk_user: ^1.9.7+3
   http: ^1.3.0
   intl: ^0.20.2
-  shared_preferences: ^2.5.3
+  cupertino_icons: ^1.0.8
+
   provider: ^6.1.4
+  flutter_dotenv: ^5.2.1
+  shared_preferences: ^2.5.3
+  
+  firebase_core: ^3.13.0
+  firebase_auth: ^5.5.2
+
+  google_sign_in: ^6.3.0
+  kakao_flutter_sdk_common: ^1.9.7+3
+  kakao_flutter_sdk_user: ^1.9.7+3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 변경 사항
- `dotenv.gradle` 수정
  - `.env` 파일 경로를 `rootProject` 기준으로 조정 (`app/.env`)
  - `KAKAO_NATIVE_APP_KEY` 환경변수 정상 로드되도록 수정
- `build.gradle.kts` 수정
  - `manifestPlaceholders`에 `.env`에서 읽어온 `KAKAO_NATIVE_APP_KEY`를 전달
- `AndroidManifest.xml` 수정
  - KakaoTalk 로그인용 `intent-filter`의 `host` 값을 `kakaolink`로 명시적으로 설정(웹에서 바로 앱으로 전환 가능)

## 기타 수정
- `pubspec.yaml` 포맷 정리

## 테스트 결과
- 카카오톡 미설치 시 웹 로그인 정상 작동
  - custom uri(`kakao{앱키}://oauth`) 처리 정상
  - Firebase와 연동하여 로그인 성공
- 이전에 성공했던 카카오톡으로 로그인과 정상적으로 연동

---

## 관련 이슈

Closes #12 
