### PR TITLE
[App] project 관련 db 메서드 구현 완료 및 에러 해결

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import 'package:talk_pilot/src/pages/base_page.dart';
 import 'package:talk_pilot/src/provider/login_provider.dart';
+import 'package:talk_pilot/src/provider/project_provider.dart';
 import 'package:talk_pilot/src/provider/user_provider.dart';
 
 class App extends StatelessWidget {
@@ -15,6 +16,7 @@ class App extends StatelessWidget {
       providers: [
         ChangeNotifierProvider(create: (_) => LoginProvider()),
         ChangeNotifierProvider(create: (_) => UserProvider()),
+        ChangeNotifierProvider(create: (_) => ProjectProvider()),
       ],
       child: MaterialApp(
         /// App title.

--- a/app/lib/src/models/project_model.dart
+++ b/app/lib/src/models/project_model.dart
@@ -1,23 +1,23 @@
 class ProjectModel {
   final String id;
-  final String name;
+  final String title;
   final String description;
   final DateTime? createdAt;
   final DateTime? updatedAt;
   final String ownerUid;
-  final List<String> participantUids;
+  final Map<String, String> participants; // "uid : role" 형식으로 저장장
   final String status; // e.g. "preparing", "completed"
   final int? estimatedTime; // 발표 예상 시간 (단위: 초)
   final double? score; // 프로젝트 점수
 
   ProjectModel({
     required this.id,
-    required this.name,
+    required this.title,
     required this.description,
     this.createdAt,
     this.updatedAt,
     required this.ownerUid,
-    required this.participantUids,
+    required this.participants,
     required this.status,
     this.estimatedTime,
     this.score,
@@ -26,17 +26,17 @@ class ProjectModel {
   factory ProjectModel.fromMap(String id, Map<String, dynamic> map) {
     return ProjectModel(
       id: id,
-      name: map['name'] ?? '',
+      title: map['title'] ?? '',
       description: map['description'] ?? '',
       createdAt:
           map['createdAt'] != null ? DateTime.tryParse(map['createdAt']) : null,
       updatedAt:
           map['updatedAt'] != null ? DateTime.tryParse(map['updatedAt']) : null,
       ownerUid: map['ownerUid'] ?? '',
-      participantUids:
-          map['participantUids'] != null
-              ? List<String>.from(map['participantUids'])
-              : [],
+      participants:
+          map['participants'] != null
+              ? Map<String, String>.from(map['participants'])
+              : {},
       status: map['status'] ?? 'preparing',
       estimatedTime:
           map['estimatedTime'] != null
@@ -48,12 +48,12 @@ class ProjectModel {
 
   Map<String, dynamic> toMap() {
     return {
-      "name": name,
+      "title": title,
       "description": description,
       if (createdAt != null) "createdAt": createdAt!.toIso8601String(),
       if (updatedAt != null) "updatedAt": updatedAt!.toIso8601String(),
       "ownerUid": ownerUid,
-      "participantUids": participantUids,
+      "participants": participants,
       "status": status,
       if (estimatedTime != null) "estimatedTime": estimatedTime,
       if (score != null) "score": score,

--- a/app/lib/src/models/project_model.dart
+++ b/app/lib/src/models/project_model.dart
@@ -74,4 +74,29 @@ class ProjectModel {
       if (score != null) "score": score,
     };
   }
+
+  ProjectModel copyWith({
+    String? title,
+    String? description,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? ownerUid,
+    Map<String, String>? participants,
+    String? status,
+    int? estimatedTime,
+    double? score,
+  }) {
+    return ProjectModel(
+      id: id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      ownerUid: ownerUid ?? this.ownerUid,
+      participants: participants ?? this.participants,
+      status: status ?? this.status,
+      estimatedTime: estimatedTime ?? this.estimatedTime,
+      score: score ?? this.score,
+    );
+  }
 }

--- a/app/lib/src/models/project_model.dart
+++ b/app/lib/src/models/project_model.dart
@@ -1,0 +1,62 @@
+class ProjectModel {
+  final String id;
+  final String name;
+  final String description;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final String ownerUid;
+  final List<String> participantUids;
+  final String status; // e.g. "preparing", "completed"
+  final int? estimatedTime; // 발표 예상 시간 (단위: 초)
+  final double? score; // 프로젝트 점수
+
+  ProjectModel({
+    required this.id,
+    required this.name,
+    required this.description,
+    this.createdAt,
+    this.updatedAt,
+    required this.ownerUid,
+    required this.participantUids,
+    required this.status,
+    this.estimatedTime,
+    this.score,
+  });
+
+  factory ProjectModel.fromMap(String id, Map<String, dynamic> map) {
+    return ProjectModel(
+      id: id,
+      name: map['name'] ?? '',
+      description: map['description'] ?? '',
+      createdAt:
+          map['createdAt'] != null ? DateTime.tryParse(map['createdAt']) : null,
+      updatedAt:
+          map['updatedAt'] != null ? DateTime.tryParse(map['updatedAt']) : null,
+      ownerUid: map['ownerUid'] ?? '',
+      participantUids:
+          map['participantUids'] != null
+              ? List<String>.from(map['participantUids'])
+              : [],
+      status: map['status'] ?? 'preparing',
+      estimatedTime:
+          map['estimatedTime'] != null
+              ? (map['estimatedTime'] as num).toInt()
+              : null,
+      score: map['score'] != null ? (map['score'] as num).toDouble() : null,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      "name": name,
+      "description": description,
+      if (createdAt != null) "createdAt": createdAt!.toIso8601String(),
+      if (updatedAt != null) "updatedAt": updatedAt!.toIso8601String(),
+      "ownerUid": ownerUid,
+      "participantUids": participantUids,
+      "status": status,
+      if (estimatedTime != null) "estimatedTime": estimatedTime,
+      if (score != null) "score": score,
+    };
+  }
+}

--- a/app/lib/src/models/project_model.dart
+++ b/app/lib/src/models/project_model.dart
@@ -1,3 +1,18 @@
+/// 변경 가능한 필드들만 정의
+enum ProjectField {
+  title,
+  description,
+  ownerUid,
+  participants,
+  status,
+  estimatedTime,
+  score,
+}
+
+extension ProjectFieldExt on ProjectField {
+  String get key => toString().split('.').last;
+}
+
 class ProjectModel {
   final String id;
   final String title;

--- a/app/lib/src/models/user_model.dart
+++ b/app/lib/src/models/user_model.dart
@@ -1,3 +1,19 @@
+/// 변경 가능한 필드들만 정의
+enum UserField {
+  email,
+  nickname,
+  photoUrl,
+  projectIds,
+  averageScore,
+  targetScore,
+  cpm,
+}
+
+extension UserFieldExt on UserField {
+  String get key => toString().split('.').last;
+}
+
+/// user의 형식 정의
 class UserModel {
   final String uid;
   final String name;

--- a/app/lib/src/pages/profile_page/profile_page.dart
+++ b/app/lib/src/pages/profile_page/profile_page.dart
@@ -19,6 +19,16 @@ class _ProfilePageState extends State<ProfilePage> {
   bool isEditingNickname = false;
 
   @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      // ignore: use_build_context_synchronously
+      final userProvider = context.read<UserProvider>();
+      userProvider.refreshUser();
+    });
+  }
+
+  @override
   void dispose() {
     nicknameController.dispose();
     super.dispose();
@@ -36,14 +46,6 @@ class _ProfilePageState extends State<ProfilePage> {
         title: const Text('프로필', style: TextStyle(color: Colors.white)),
         iconTheme: const IconThemeData(color: Colors.white),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            tooltip: '새로고침',
-            onPressed: () async {
-              final userProvider = context.read<UserProvider>();
-              await userProvider.refreshUser();
-            },
-          ),
           IconButton(
             icon: const Icon(Icons.settings),
             tooltip: '설정',

--- a/app/lib/src/pages/profile_page/profile_page.dart
+++ b/app/lib/src/pages/profile_page/profile_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:talk_pilot/src/models/user_model.dart';
 
 import 'package:talk_pilot/src/provider/user_provider.dart';
 import 'package:talk_pilot/src/pages/profile_page/widgets/profile_card.dart';
@@ -82,11 +83,13 @@ class _ProfilePageState extends State<ProfilePage> {
               },
               onNicknameSubmit: (value) async {
                 if (userModel != null) {
-                  final updated = userModel.copyWith(
-                    nickname: value,
-                    updatedAt: DateTime.now(),
-                  );
-                  await context.read<UserProvider>().updateUser(updated);
+                  // final updated = userModel.copyWith(
+                  //   nickname: value,
+                  //   updatedAt: DateTime.now(),
+                  // );
+                  await context.read<UserProvider>().updateUser({
+                    UserField.nickname: value,
+                  });
                   setState(() => isEditingNickname = false);
                 }
               },

--- a/app/lib/src/provider/login_provider.dart
+++ b/app/lib/src/provider/login_provider.dart
@@ -20,7 +20,7 @@ class LoginProvider with ChangeNotifier {
     });
   }
 
-  /// 로그인 수행 (SocialLogin 객체를 받음)
+  /// 로그인 수행 [SocialLogin]
   Future<void> login(SocialLogin loginProvider) async {
     try {
       final user = await loginProvider.login();

--- a/app/lib/src/provider/project_provider.dart
+++ b/app/lib/src/provider/project_provider.dart
@@ -10,28 +10,24 @@ class ProjectProvider with ChangeNotifier {
   final ProjectService _projectService = ProjectService();
   final UserService _userService = UserService();
 
-  List<ProjectModel> _projects = [];
+  final List<ProjectModel> _projects = [];
   ProjectModel? _selectedProject;
 
   List<ProjectModel> get projects => List.unmodifiable(_projects);
   ProjectModel? get selectedProject => _selectedProject;
 
-  Future<void> loadUserProjects(String uid) async {
+  set selectedProject(ProjectModel? project) {
+    _selectedProject = project;
+    notifyListeners();
+  }
+
+  Future<void> loadProjects(String uid) async {
     final allProjects = await _projectService.fetchProjects(uid);
     final userProjects =
         allProjects.where((p) => p.participants.containsKey(uid)).toList();
     _projects
       ..clear()
       ..addAll(userProjects);
-    notifyListeners();
-  }
-
-  void selectProject(String projectId) {
-    try {
-      _selectedProject = _projects.firstWhere((p) => p.id == projectId);
-    } catch (_) {
-      _selectedProject = null;
-    }
     notifyListeners();
   }
 

--- a/app/lib/src/provider/project_provider.dart
+++ b/app/lib/src/provider/project_provider.dart
@@ -55,6 +55,8 @@ class ProjectProvider with ChangeNotifier {
       "updatedAt": DateTime.now().toIso8601String(),
     });
 
+    /// 로컬에 추가된 프로젝트 반영
+    /// refresh 필요 없음
     _projects.insert(0, newProject);
     _selectedProject = newProject;
     notifyListeners();

--- a/app/lib/src/provider/project_provider.dart
+++ b/app/lib/src/provider/project_provider.dart
@@ -39,12 +39,10 @@ class ProjectProvider with ChangeNotifier {
       newProject.id: newProject.status,
     };
 
-    final updatedUser = currentUser.copyWith(
-      projectIds: updatedProjectIds,
-      updatedAt: DateTime.now(),
-    );
-
-    await _userService.updateUser(updatedUser);
+    await _userService.updateUser(currentUser.uid, {
+      "projectIds": updatedProjectIds,
+      "updatedAt": DateTime.now().toIso8601String(),
+    });
 
     _projects.insert(0, newProject);
     notifyListeners();
@@ -54,12 +52,18 @@ class ProjectProvider with ChangeNotifier {
     String projectId,
     Map<String, dynamic> updates,
   ) async {
-    await _projectService.updateProject(projectId, updates);
+    final fullUpdates = {
+      ...updates,
+      'updatedAt': DateTime.now().toIso8601String(), // 자동으로 updateAt 갱신
+    };
+
+    await _projectService.updateProject(projectId, fullUpdates);
+
     final index = _projects.indexWhere((p) => p.id == projectId);
     if (index != -1) {
       final updated = ProjectModel.fromMap(projectId, {
         ..._projects[index].toMap(),
-        ...updates,
+        ...fullUpdates,
       });
       _projects[index] = updated;
       notifyListeners();

--- a/app/lib/src/provider/project_provider.dart
+++ b/app/lib/src/provider/project_provider.dart
@@ -15,7 +15,7 @@ class ProjectProvider with ChangeNotifier {
   Future<void> loadUserProjects(String uid) async {
     final projects = await _projectService.fetchProjects(uid);
     final userProjects =
-        projects.where((p) => p.participantUids.contains(uid)).toList();
+        projects.where((p) => p.participants.containsValue(uid)).toList();
     _projects
       ..clear()
       ..addAll(userProjects);
@@ -23,15 +23,15 @@ class ProjectProvider with ChangeNotifier {
   }
 
   Future<void> createProject({
-    required String name,
+    required String title,
     required String description,
     required UserModel currentUser,
   }) async {
     final newProject = await _projectService.writeProject(
-      name: name,
+      title: title,
       description: description,
       ownerUid: currentUser.uid,
-      participantUids: [currentUser.uid],
+      participants: {currentUser.uid: "Owner"},
     );
 
     final updatedProjectIds = {

--- a/app/lib/src/provider/project_provider.dart
+++ b/app/lib/src/provider/project_provider.dart
@@ -21,6 +21,7 @@ class ProjectProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  /// 프로젝트 리스트 불러오기
   Future<void> loadProjects(String uid) async {
     final allProjects = await _projectService.fetchProjects(uid);
     final userProjects =
@@ -31,6 +32,7 @@ class ProjectProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  /// 프로젝트 생성
   Future<void> createProject({
     required String title,
     required String description,
@@ -58,6 +60,7 @@ class ProjectProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  /// 프로젝트 새로고침
   Future<void> refreshProject() async {
     if (_selectedProject == null) return;
     final latest = await _projectService.readProject(_selectedProject!.id);
@@ -69,6 +72,7 @@ class ProjectProvider with ChangeNotifier {
     }
   }
 
+  /// 프로젝트 업데이트
   Future<void> updateProject(Map<ProjectField, dynamic> updates) async {
     if (_selectedProject == null) return;
     final updateMap = {
@@ -79,6 +83,7 @@ class ProjectProvider with ChangeNotifier {
     await refreshProject(); // 업데이트한 정보로 갱신
   }
 
+  /// 프로젝트 삭제
   Future<void> deleteProject() async {
     if (_selectedProject == null) return;
     await _projectService.deleteProject(_selectedProject!.id);

--- a/app/lib/src/provider/project_provider.dart
+++ b/app/lib/src/provider/project_provider.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+import 'package:talk_pilot/src/models/user_model.dart';
+import 'package:talk_pilot/src/models/project_model.dart';
+
+import 'package:talk_pilot/src/services/database/user_service.dart';
+import 'package:talk_pilot/src/services/database/project_service.dart';
+
+class ProjectProvider with ChangeNotifier {
+  final ProjectService _projectService = ProjectService();
+  final UserService _userService = UserService();
+  final List<ProjectModel> _projects = [];
+
+  List<ProjectModel> get projects => List.unmodifiable(_projects);
+  Future<void> loadUserProjects(String uid) async {
+    final projects = await _projectService.fetchProjects(uid);
+    final userProjects =
+        projects.where((p) => p.participantUids.contains(uid)).toList();
+    _projects
+      ..clear()
+      ..addAll(userProjects);
+    notifyListeners();
+  }
+
+  Future<void> createProject({
+    required String name,
+    required String description,
+    required UserModel currentUser,
+  }) async {
+    final newProject = await _projectService.writeProject(
+      name: name,
+      description: description,
+      ownerUid: currentUser.uid,
+      participantUids: [currentUser.uid],
+    );
+
+    final updatedProjectIds = {
+      ...?currentUser.projectIds,
+      newProject.id: newProject.status,
+    };
+
+    final updatedUser = currentUser.copyWith(
+      projectIds: updatedProjectIds,
+      updatedAt: DateTime.now(),
+    );
+
+    await _userService.updateUser(updatedUser);
+
+    _projects.insert(0, newProject);
+    notifyListeners();
+  }
+
+  Future<void> updateProject(
+    String projectId,
+    Map<String, dynamic> updates,
+  ) async {
+    await _projectService.updateProject(projectId, updates);
+    final index = _projects.indexWhere((p) => p.id == projectId);
+    if (index != -1) {
+      final updated = ProjectModel.fromMap(projectId, {
+        ..._projects[index].toMap(),
+        ...updates,
+      });
+      _projects[index] = updated;
+      notifyListeners();
+    }
+  }
+
+  Future<void> deleteProject(String projectId) async {
+    await _projectService.deleteProject(projectId);
+    _projects.removeWhere((p) => p.id == projectId);
+    notifyListeners();
+  }
+}

--- a/app/lib/src/provider/user_provider.dart
+++ b/app/lib/src/provider/user_provider.dart
@@ -14,19 +14,8 @@ class UserProvider with ChangeNotifier {
     final user = await _userService.readUser(uid);
     if (user != null) {
       _currentUser = user;
-    } else {
-      // 최초 로그인 시 기본 UserModel 생성
-      _currentUser = UserModel(
-        uid: uid,
-        name: '',
-        email: '',
-        nickname: '',
-        createdAt: DateTime.now(),
-        updatedAt: DateTime.now(),
-      );
-      await _userService.writeUser(_currentUser!);
+      notifyListeners();
     }
-    notifyListeners();
   }
 
   Future<void> refreshUser() async {

--- a/app/lib/src/provider/user_provider.dart
+++ b/app/lib/src/provider/user_provider.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:talk_pilot/src/models/user_model.dart';
-import 'package:talk_pilot/src/components/toast_message.dart';
 import 'package:talk_pilot/src/services/database/user_service.dart';
 
 class UserProvider with ChangeNotifier {
@@ -11,6 +10,7 @@ class UserProvider with ChangeNotifier {
   UserModel? get currentUser => _currentUser;
   bool get hasUser => _currentUser != null;
 
+  /// 유저정보 로드
   Future<void> loadUser(String uid) async {
     final user = await _userService.readUser(uid);
     if (user != null) {
@@ -19,16 +19,17 @@ class UserProvider with ChangeNotifier {
     }
   }
 
+  /// 유저정보 새로고침
   Future<void> refreshUser() async {
     if (_currentUser == null) return;
     final latest = await _userService.readUser(_currentUser!.uid);
     if (latest != null) {
       _currentUser = latest;
-      ToastMessage.show("유저 정보를 다시 불러옵니다.");
       notifyListeners();
     }
   }
 
+  /// 유저 업데이트
   Future<void> updateUser(Map<UserField, dynamic> updates) async {
     if (_currentUser == null) return;
     final updateMap = {
@@ -38,6 +39,7 @@ class UserProvider with ChangeNotifier {
     await refreshUser(); // 업데이트한 정보로 갱신
   }
 
+  /// 유저 삭제(로컬에서)
   void clearUser() {
     _currentUser = null;
     notifyListeners();

--- a/app/lib/src/provider/user_provider.dart
+++ b/app/lib/src/provider/user_provider.dart
@@ -38,10 +38,16 @@ class UserProvider with ChangeNotifier {
     }
   }
 
-  Future<void> updateUser(UserModel updatedUser) async {
-    _currentUser = updatedUser;
-    await _userService.updateUser(updatedUser);
-    notifyListeners();
+  Future<void> updateUser(Map<UserField, dynamic> updates) async {
+    if (_currentUser == null) return;
+
+    final updateMap = {
+      for (final entry in updates.entries) entry.key.key: entry.value,
+    };
+
+    await _userService.updateUser(_currentUser!.uid, updateMap);
+
+    await refreshUser(); // 업데이트한 정보로 갱신
   }
 
   void clearUser() {

--- a/app/lib/src/provider/user_provider.dart
+++ b/app/lib/src/provider/user_provider.dart
@@ -29,13 +29,10 @@ class UserProvider with ChangeNotifier {
 
   Future<void> updateUser(Map<UserField, dynamic> updates) async {
     if (_currentUser == null) return;
-
     final updateMap = {
       for (final entry in updates.entries) entry.key.key: entry.value,
     };
-
     await _userService.updateUser(_currentUser!.uid, updateMap);
-
     await refreshUser(); // 업데이트한 정보로 갱신
   }
 

--- a/app/lib/src/services/database/project_service.dart
+++ b/app/lib/src/services/database/project_service.dart
@@ -1,5 +1,5 @@
-import 'package:firebase_database/firebase_database.dart';
 import 'package:uuid/uuid.dart';
+import 'package:firebase_database/firebase_database.dart';
 import 'package:talk_pilot/src/models/project_model.dart';
 import 'package:talk_pilot/src/services/database/database_service.dart';
 
@@ -31,6 +31,8 @@ class ProjectService {
     );
 
     await _db.writeDB('$basePath/$id', project.toMap());
+
+    /// createProject()에서 유저랑 연동하기 위함
     return project;
   }
 
@@ -43,7 +45,7 @@ class ProjectService {
   Future<void> updateProject(String id, Map<String, dynamic> updates) async {
     final fullUpdates = {
       ...updates,
-      'updatedAt': DateTime.now().toIso8601String(),
+      'updatedAt': DateTime.now().toIso8601String(), // 자동으로 updateAt 갱신
     };
     await _db.updateDB('$basePath/$id', fullUpdates);
   }

--- a/app/lib/src/services/database/project_service.dart
+++ b/app/lib/src/services/database/project_service.dart
@@ -1,0 +1,37 @@
+import 'package:firebase_database/firebase_database.dart';
+import 'package:talk_pilot/src/models/project_model.dart';
+import 'package:talk_pilot/src/services/database/database_service.dart';
+
+class ProjectService {
+  final DatabaseService _db = DatabaseService();
+  final String basePath = 'projects';
+
+  Future<void> writeProject(ProjectModel project) async {
+    await _db.writeDB('$basePath/${project.id}', project.toMap());
+  }
+
+  Future<ProjectModel?> readProject(String id) async {
+    final data = await _db.readDB<Map<String, dynamic>>('$basePath/$id');
+    if (data == null) return null;
+    return ProjectModel.fromMap(id, data);
+  }
+
+  Future<void> updateProject(String id, Map<String, dynamic> updates) async {
+    await _db.updateDB('$basePath/$id', updates);
+  }
+
+  Future<void> deleteProject(String id) async {
+    await _db.deleteDB('$basePath/$id');
+  }
+
+  Future<List<ProjectModel>> fetchUserProjects(String uid) async {
+    return await _db.fetchDB<ProjectModel>(
+      path: basePath,
+      fromMap: (map) => ProjectModel.fromMap(map['id'], map),
+      query: FirebaseDatabase.instance
+          .ref(basePath)
+          .orderByChild('participants/$uid')
+          .equalTo(true),
+    );
+  }
+}

--- a/app/lib/src/services/database/project_service.dart
+++ b/app/lib/src/services/database/project_service.dart
@@ -8,23 +8,25 @@ class ProjectService {
   final String basePath = 'projects';
   final _uuid = const Uuid();
 
+  /// user쪽에도 [projectId]를 업데이트 해야함.
+  /// projectModel을 return.
   Future<ProjectModel> writeProject({
-    required String name,
+    required String title,
     required String description,
     required String ownerUid,
-    required List<String> participantUids,
+    required Map<String, String> participants,
   }) async {
     final now = DateTime.now();
     final id = _uuid.v4();
 
     final project = ProjectModel(
       id: id,
-      name: name,
+      title: title,
       description: description,
       createdAt: now,
       updatedAt: now,
       ownerUid: ownerUid,
-      participantUids: participantUids,
+      participants: participants,
       status: 'preparing',
     );
 
@@ -57,7 +59,7 @@ class ProjectService {
           final project = ProjectModel.fromMap(child.key!, map);
           return project;
         })
-        .where((project) => project.participantUids.contains(uid))
+        .where((project) => project.participants.containsKey(uid))
         .toList();
   }
 }

--- a/app/lib/src/services/database/project_service.dart
+++ b/app/lib/src/services/database/project_service.dart
@@ -41,7 +41,11 @@ class ProjectService {
   }
 
   Future<void> updateProject(String id, Map<String, dynamic> updates) async {
-    await _db.updateDB('$basePath/$id', updates);
+    final fullUpdates = {
+      ...updates,
+      'updatedAt': DateTime.now().toIso8601String(),
+    };
+    await _db.updateDB('$basePath/$id', fullUpdates);
   }
 
   Future<void> deleteProject(String id) async {

--- a/app/lib/src/services/database/user_service.dart
+++ b/app/lib/src/services/database/user_service.dart
@@ -19,8 +19,12 @@ class UserService {
     return UserModel.fromMap(uid, map);
   }
 
-  Future<void> updateUser(UserModel user) async {
-    await _db.updateDB("users/${user.uid}", user.toMap());
+  Future<void> updateUser(String uid, Map<String, dynamic> updates) async {
+    final fullUpdates = {
+      ...updates,
+      'updatedAt': DateTime.now().toIso8601String(), // 자동으로 updateAt 갱신
+    };
+    await _db.updateDB("users/$uid", fullUpdates);
   }
 
   Future<void> deleteUser(String uid) async {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.6+11"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -549,6 +557,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -597,6 +613,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uuid:
+    dependency: "direct main"
+    description:
+      name: uuid
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.1"
   vector_math:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   firebase_core: ^3.13.0
   firebase_auth: ^5.5.2
   firebase_database: ^11.3.5
+  uuid: ^4.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 프로젝트 모델 기능 신규 구현

- `project_model` 정의 및 필드 구조 설계
  - 참여자 구조를 `Map<String, String>` 형태로 설계 (uid : role)
  - `estimatedTime`, `score` 등 발표 관련 정보 포함
- `ProjectField` enum 정의 및 `copyWith` 메서드 구현
  - enum으로 변경 가능한 필드 정의
  - `copyWith`는 상태관리에 이용할 예정
- `ProjectService` 작성: 프로젝트 생성, 읽기, 수정, 삭제 기능 포함
  - `updateUser()`와 마찬가지로 변경된 내용만 update함.
- `ProjectProvider` 구현:
  - `loadProjects()` : 유저가 참여하는 프로젝트 리스트를 불러옴.
  - `createProject()` : 새 프로젝트 생성
  - `refreshProject()` : 프로젝트 새로고침(_selectedProject에만 적용)
  - `updateProject()` : 프로젝트 변경사항 반영
  - `deleteProject()` : 프로젝트 삭제 
  - provider에서 setter를 통해 `selectedProject` 접근 가능
- app.dart의 MultiProvider에 ProjectProvider 추가

---

## 구조 개선

- `UserProvider.updateUser()` 개선
  - 변경된 필드만 업데이트하는 방식으로 수정
- `user_model` 내 필드 추가 및 유지보수
  - enum으로 변경가능 필드를 정의하고 사용하여 업데이트 로직 간결화

***기존 방식***

변경사항을 이용하여 새로운 `user_model` 객체를 만들고 이를 전달.
전달받은 객체 전체를 업데이트함.

```
final updated = userModel.copyWith(
  nickname: value,
  updatedAt: DateTime.now(),
);
await context.read<UserProvider>().updateUser(updated);
```

***새로운 방식***

`user_field`로 변경 가능한 필드만 입력 가능.
변경사항만 Map<UserField, dynamic> 타입의 `updates` 파라미터로 전달.
DB에도 변경된 사항만 전송 및 변경(자동으로 `updateAt` 갱신)

```
await context.read<UserProvider>().updateUser({
  UserField.nickname: value,
});
```

*`updateProject()`도 동일한 방식 적용

---

## 기타 병합 사항
- `main` 브랜치와의 병합 처리 완료
  - `toast_message.dart` 등 공통 컴포넌트 포함 변경 사항 병합 반영
  - 초기에 db에 초기 정보를 저장하고 이를 가져오지 못하는 문제 해결
    - `user_provider`의 초기값 세팅 삭제 (`user_service`로 책임 전가)
    - `profile_page` 진입 시, 강제로 새로 고침 (초기값 세팅 이후 다시 정보 로드)

---

## 참고사항

- 이를 이용하여 `work_page`에 프로젝트들을 불러와야함.
- 위 메서드들을 통해서 프로젝트 생성 및 수정이 가능한 UI를 만들고 연결해야함.
- 빠른 시간 내로 관련 이슈 작성 예정

---


## 관련 이슈

Closes #29
Closes #24 