### PR TITLE
[App] 발표 연습 기능 추가 및 발표 결과 기능 추가

### DIFF
--- a/app/lib/src/pages/practice_page/presentation_practice_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_practice_page.dart
@@ -115,8 +115,16 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        const Text(
+          '대본:',
+          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+        ),
         RichText(text: TextSpan(children: scriptSpans)),
-        const SizedBox(height: 4),
+        const SizedBox(height: 8),
+        const Text(
+          '인식 결과:',
+          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+        ),
         RichText(text: TextSpan(children: recognizedSpans)),
       ],
     );
@@ -167,11 +175,6 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
               style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
             ),
             const SizedBox(height: 24),
-            const Text(
-              '대본 및 인식 결과:',
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 12),
             Expanded(
               child: Container(
                 padding: const EdgeInsets.all(16),

--- a/app/lib/src/pages/practice_page/presentation_practice_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_practice_page.dart
@@ -45,72 +45,69 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
           fontWeight: FontWeight.bold,
         ),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor:
-                    _controller.isListening ? Colors.grey : Colors.deepPurple,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(vertical: 16),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: _controller.isListening
+                      ? Colors.grey
+                      : Colors.deepPurple,
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+                onPressed: _controller.isListening
+                    ? _controller.stopListening
+                    : _controller.startListening,
+                child:
+                    Text(_controller.isListening ? '발표 중지' : '발표 시작'),
               ),
-              onPressed:
-                  _controller.isListening
-                      ? _controller.stopListening
-                      : _controller.startListening,
-              child: Text(_controller.isListening ? '발표 중지' : '발표 시작'),
-            ),
-            const SizedBox(height: 16),
-
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                InfoCard(title: '현재 속도', value: _controller.cpmStatus),
-                InfoCard(
-                  title: '진행도',
-                  value:
-                      '${(_controller.scriptProgress * 100).toStringAsFixed(1)}%',
-                ),
-                InfoCard(
-                  title: '정확도',
-                  value:
-                      '${(_controller.scriptAccuracy * 100).toStringAsFixed(1)}%',
-                ),
-              ],
-            ),
-
-            const SizedBox(height: 24),
-            Expanded(
-              child: Container(
+              const SizedBox(height: 16),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  InfoCard(title: '현재 속도', value: _controller.cpmStatus),
+                  InfoCard(
+                    title: '진행도',
+                    value:
+                        '${(_controller.scriptProgress * 100).toStringAsFixed(1)}%',
+                  ),
+                  InfoCard(
+                    title: '정확도',
+                    value:
+                        '${(_controller.scriptAccuracy * 100).toStringAsFixed(1)}%',
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              Container(
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
                   border: Border.all(color: Colors.deepPurple),
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: SingleChildScrollView(
-                  child: ScriptComparisonView(
-                    scriptChunks: _controller.scriptChunks,
-                    recognizedText: _controller.recognizedText,
-                    isSimilar: _controller.isSimilar,
-                    splitText: _controller.splitText,
-                  ),
+                child: ScriptComparisonView(
+                  scriptChunks: _controller.scriptChunks,
+                  recognizedText: _controller.recognizedText,
+                  isSimilar: _controller.isSimilar,
+                  splitText: _controller.splitText,
                 ),
               ),
-            ),
-            const SizedBox(height: 16),
-            ResultButton(
-              progress: _controller.scriptProgress,
-              accuracy: _controller.scriptAccuracy,
-              actualCpm: _controller.currentCpm,
-              userCpm: _controller.userCpm,
-              cpmStatus: _controller.cpmStatus,
-              actualDuration: _controller.presentationDuration,
-              expectedDuration: _controller.expectedDuration,
-            ),
-          ],
+              const SizedBox(height: 16),
+              ResultButton(
+                progress: _controller.scriptProgress,
+                accuracy: _controller.scriptAccuracy,
+                actualCpm: _controller.currentCpm,
+                userCpm: _controller.userCpm,
+                cpmStatus: _controller.cpmStatus,
+                actualDuration: _controller.presentationDuration,
+                expectedDuration: _controller.expectedDuration,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/app/lib/src/pages/practice_page/presentation_practice_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_practice_page.dart
@@ -2,13 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:talk_pilot/src/pages/practice_page/widgets/presentation_practice_controller.dart';
 import 'package:talk_pilot/src/pages/practice_page/widgets/script_comparison_view.dart';
 import 'package:talk_pilot/src/pages/practice_page/widgets/result_button.dart';
+import 'package:talk_pilot/src/pages/practice_page/widgets/info_card.dart';
 
 class PresentationPracticePage extends StatefulWidget {
   final String projectId;
   const PresentationPracticePage({super.key, required this.projectId});
 
   @override
-  State<PresentationPracticePage> createState() => _PresentationPracticePageState();
+  State<PresentationPracticePage> createState() =>
+      _PresentationPracticePageState();
 }
 
 class _PresentationPracticePageState extends State<PresentationPracticePage> {
@@ -50,30 +52,36 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
           children: [
             ElevatedButton(
               style: ElevatedButton.styleFrom(
-                backgroundColor: _controller.isListening ? Colors.grey : Colors.deepPurple,
+                backgroundColor:
+                    _controller.isListening ? Colors.grey : Colors.deepPurple,
                 foregroundColor: Colors.white,
                 padding: const EdgeInsets.symmetric(vertical: 16),
               ),
-              onPressed: _controller.isListening
-                  ? _controller.stopListening
-                  : _controller.startListening,
+              onPressed:
+                  _controller.isListening
+                      ? _controller.stopListening
+                      : _controller.startListening,
               child: Text(_controller.isListening ? '발표 중지' : '발표 시작'),
             ),
             const SizedBox(height: 16),
-            Text(
-              '현재 CPM: ${_controller.currentCpm.toStringAsFixed(1)} (${_controller.cpmStatus})',
-              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                InfoCard(title: '현재 속도', value: _controller.cpmStatus),
+                InfoCard(
+                  title: '진행도',
+                  value:
+                      '${(_controller.scriptProgress * 100).toStringAsFixed(1)}%',
+                ),
+                InfoCard(
+                  title: '정확도',
+                  value:
+                      '${(_controller.scriptAccuracy * 100).toStringAsFixed(1)}%',
+                ),
+              ],
             ),
-            const SizedBox(height: 8),
-            Text(
-              '진행도: ${(_controller.scriptProgress * 100).toStringAsFixed(1)}%',
-              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              '정확도: ${(_controller.scriptAccuracy * 100).toStringAsFixed(1)}%',
-              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
-            ),
+
             const SizedBox(height: 24),
             Expanded(
               child: Container(

--- a/app/lib/src/pages/practice_page/presentation_practice_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_practice_page.dart
@@ -54,7 +54,9 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
                 foregroundColor: Colors.white,
                 padding: const EdgeInsets.symmetric(vertical: 16),
               ),
-              onPressed: _controller.isListening ? _controller.stopListening : _controller.startListening,
+              onPressed: _controller.isListening
+                  ? _controller.stopListening
+                  : _controller.startListening,
               child: Text(_controller.isListening ? '발표 중지' : '발표 시작'),
             ),
             const SizedBox(height: 16),
@@ -94,6 +96,8 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
             ResultButton(
               progress: _controller.scriptProgress,
               accuracy: _controller.scriptAccuracy,
+              actualCpm: _controller.currentCpm,
+              userCpm: _controller.userCpm,
               cpmStatus: _controller.cpmStatus,
               actualDuration: _controller.presentationDuration,
               expectedDuration: _controller.expectedDuration,

--- a/app/lib/src/pages/practice_page/presentation_practice_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_practice_page.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class PresentationPracticePage extends StatelessWidget {
+  final String projectId;
+  const PresentationPracticePage({super.key, required this.projectId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('발표 연습'),
+        backgroundColor: Colors.deepPurple,
+        iconTheme: const IconThemeData(color: Colors.white),
+        titleTextStyle: const TextStyle(
+          color: Colors.white,
+          fontSize: 20,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      body: const Center(
+        child: Text(
+          '발표 연습 기능은 준비 중입니다.',
+          style: TextStyle(fontSize: 16),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/src/pages/practice_page/presentation_practice_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_practice_page.dart
@@ -46,7 +46,7 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
         ),
       ),
       body: SafeArea(
-        child: SingleChildScrollView(
+        child: Padding(
           padding: const EdgeInsets.all(20),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -62,8 +62,8 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
                 onPressed: _controller.isListening
                     ? _controller.stopListening
                     : _controller.startListening,
-                child:
-                    Text(_controller.isListening ? '발표 중지' : '발표 시작'),
+                child: Text(
+                    _controller.isListening ? '발표 중지' : '발표 시작'),
               ),
               const SizedBox(height: 16),
               Row(
@@ -83,17 +83,21 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
                 ],
               ),
               const SizedBox(height: 24),
-              Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  border: Border.all(color: Colors.deepPurple),
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: ScriptComparisonView(
-                  scriptChunks: _controller.scriptChunks,
-                  recognizedText: _controller.recognizedText,
-                  isSimilar: _controller.isSimilar,
-                  splitText: _controller.splitText,
+              Expanded(
+                child: Container(
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    border: Border.all(color: Colors.deepPurple),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: SingleChildScrollView(
+                    child: ScriptComparisonView(
+                      scriptChunks: _controller.scriptChunks,
+                      recognizedText: _controller.recognizedText,
+                      isSimilar: _controller.isSimilar,
+                      splitText: _controller.splitText,
+                    ),
+                  ),
                 ),
               ),
               const SizedBox(height: 16),

--- a/app/lib/src/pages/practice_page/presentation_practice_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_practice_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:talk_pilot/src/pages/practice_page/presentation_result_page.dart';
 import 'package:talk_pilot/src/pages/practice_page/widgets/presentation_practice_controller.dart';
 import 'widgets/script_comparison_view.dart';
 
@@ -7,7 +8,8 @@ class PresentationPracticePage extends StatefulWidget {
   const PresentationPracticePage({super.key, required this.projectId});
 
   @override
-  State<PresentationPracticePage> createState() => _PresentationPracticePageState();
+  State<PresentationPracticePage> createState() =>
+      _PresentationPracticePageState();
 }
 
 class _PresentationPracticePageState extends State<PresentationPracticePage> {
@@ -49,11 +51,15 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
           children: [
             ElevatedButton(
               style: ElevatedButton.styleFrom(
-                backgroundColor: _controller.isListening ? Colors.grey : Colors.deepPurple,
+                backgroundColor:
+                    _controller.isListening ? Colors.grey : Colors.deepPurple,
                 foregroundColor: Colors.white,
                 padding: const EdgeInsets.symmetric(vertical: 16),
               ),
-              onPressed: _controller.isListening ? _controller.stopListening : _controller.startListening,
+              onPressed:
+                  _controller.isListening
+                      ? _controller.stopListening
+                      : _controller.startListening,
               child: Text(_controller.isListening ? '발표 중지' : '발표 시작'),
             ),
             const SizedBox(height: 16),
@@ -83,6 +89,23 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
                   ),
                 ),
               ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const PresentationResultPage(),
+                  ),
+                );
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.deepPurple,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 16),
+              ),
+              child: const Text('결과 보러 가기'),
             ),
           ],
         ),

--- a/app/lib/src/pages/practice_page/presentation_practice_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_practice_page.dart
@@ -1,15 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:talk_pilot/src/pages/practice_page/widgets/presentation_practice_controller.dart';
-import 'package:talk_pilot/src/pages/practice_page/presentation_result_page.dart';
-import 'widgets/script_comparison_view.dart';
+import 'package:talk_pilot/src/pages/practice_page/widgets/script_comparison_view.dart';
+import 'package:talk_pilot/src/pages/practice_page/widgets/result_button.dart';
 
 class PresentationPracticePage extends StatefulWidget {
   final String projectId;
   const PresentationPracticePage({super.key, required this.projectId});
 
   @override
-  State<PresentationPracticePage> createState() =>
-      _PresentationPracticePageState();
+  State<PresentationPracticePage> createState() => _PresentationPracticePageState();
 }
 
 class _PresentationPracticePageState extends State<PresentationPracticePage> {
@@ -51,15 +50,11 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
           children: [
             ElevatedButton(
               style: ElevatedButton.styleFrom(
-                backgroundColor:
-                    _controller.isListening ? Colors.grey : Colors.deepPurple,
+                backgroundColor: _controller.isListening ? Colors.grey : Colors.deepPurple,
                 foregroundColor: Colors.white,
                 padding: const EdgeInsets.symmetric(vertical: 16),
               ),
-              onPressed:
-                  _controller.isListening
-                      ? _controller.stopListening
-                      : _controller.startListening,
+              onPressed: _controller.isListening ? _controller.stopListening : _controller.startListening,
               child: Text(_controller.isListening ? '발표 중지' : '발표 시작'),
             ),
             const SizedBox(height: 16),
@@ -70,6 +65,11 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
             const SizedBox(height: 8),
             Text(
               '진행도: ${(_controller.scriptProgress * 100).toStringAsFixed(1)}%',
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '정확도: ${(_controller.scriptAccuracy * 100).toStringAsFixed(1)}%',
               style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
             ),
             const SizedBox(height: 24),
@@ -91,28 +91,12 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
               ),
             ),
             const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder:
-                        (_) => PresentationResultPage(
-                          scriptAccuracy:
-                              _controller.scriptAccuracy,
-                          cpmStatus: _controller.cpmStatus,
-                          actualDuration: _controller.presentationDuration,
-                          expectedDuration: _controller.expectedDuration,
-                        ),
-                  ),
-                );
-              },
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.deepPurple,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(vertical: 16),
-              ),
-              child: const Text('결과 보러 가기'),
+            ResultButton(
+              progress: _controller.scriptProgress,
+              accuracy: _controller.scriptAccuracy,
+              cpmStatus: _controller.cpmStatus,
+              actualDuration: _controller.presentationDuration,
+              expectedDuration: _controller.expectedDuration,
             ),
           ],
         ),

--- a/app/lib/src/pages/practice_page/presentation_practice_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_practice_page.dart
@@ -3,7 +3,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:talk_pilot/src/services/stt/stt_service.dart';
 import 'package:talk_pilot/src/services/practice/live_cpm_service.dart';
 import 'package:talk_pilot/src/services/database/user_service.dart';
-import 'package:talk_pilot/src/models/user_model.dart';
 
 class PresentationPracticePage extends StatefulWidget {
   final String projectId;

--- a/app/lib/src/pages/practice_page/presentation_practice_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_practice_page.dart
@@ -1,8 +1,48 @@
 import 'package:flutter/material.dart';
+import 'package:talk_pilot/src/services/stt/stt_service.dart';
 
-class PresentationPracticePage extends StatelessWidget {
+class PresentationPracticePage extends StatefulWidget {
   final String projectId;
   const PresentationPracticePage({super.key, required this.projectId});
+
+  @override
+  State<PresentationPracticePage> createState() => _PresentationPracticePageState();
+}
+
+class _PresentationPracticePageState extends State<PresentationPracticePage> {
+  final SttService _sttService = SttService();
+  String _recognizedText = '';
+  bool _isListening = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _sttService.init();
+  }
+
+  void _startListening() {
+    _sttService.startListening((text) {
+      if (!mounted) return;
+      setState(() {
+        _recognizedText = text;
+        _isListening = true;
+      });
+    });
+  }
+
+  void _stopListening() async {
+    await _sttService.stopListening();
+    if (!mounted) return;
+    setState(() {
+      _isListening = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _sttService.stopListening();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -17,10 +57,44 @@ class PresentationPracticePage extends StatelessWidget {
           fontWeight: FontWeight.bold,
         ),
       ),
-      body: const Center(
-        child: Text(
-          '발표 연습 기능은 준비 중입니다.',
-          style: TextStyle(fontSize: 16),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: _isListening ? Colors.grey : Colors.deepPurple,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 16),
+              ),
+              onPressed: _isListening ? _stopListening : _startListening,
+              child: Text(_isListening ? '발표 중지' : '발표 시작'),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              '인식된 내용:',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            Expanded(
+              child: Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.deepPurple),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: SingleChildScrollView(
+                  child: Text(
+                    _recognizedText.isEmpty
+                        ? '아직 인식된 내용이 없습니다.'
+                        : _recognizedText,
+                    style: const TextStyle(fontSize: 16),
+                  ),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/app/lib/src/pages/practice_page/presentation_practice_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_practice_page.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:talk_pilot/src/services/stt/stt_service.dart';
-import 'package:talk_pilot/src/services/practice/live_cpm_service.dart';
-import 'package:talk_pilot/src/services/database/user_service.dart';
-import 'package:talk_pilot/src/services/practice/script_progress_service.dart';
+import 'package:talk_pilot/src/pages/practice_page/widgets/presentation_practice_controller.dart';
+import 'widgets/script_comparison_view.dart';
 
 class PresentationPracticePage extends StatefulWidget {
   final String projectId;
@@ -14,126 +11,21 @@ class PresentationPracticePage extends StatefulWidget {
 }
 
 class _PresentationPracticePageState extends State<PresentationPracticePage> {
-  final SttService _sttService = SttService();
-  final LiveCpmService _cpmService = LiveCpmService();
-  final ScriptProgressService _progressService = ScriptProgressService();
-
-  String _recognizedText = '';
-  bool _isListening = false;
-  double _currentCpm = 0.0;
-  String _cpmStatus = '';
-  double _userCpm = 0.0;
-  double _scriptProgress = 0.0;
+  late final PresentationPracticeController _controller;
 
   @override
   void initState() {
     super.initState();
-    _sttService.init();
-    _loadUserCpm();
-    _loadScript();
-  }
-
-  void _loadUserCpm() async {
-    final user = FirebaseAuth.instance.currentUser;
-    if (user == null) return;
-
-    final userModel = await UserService().readUser(user.uid);
-    if (userModel == null) return;
-
-    setState(() {
-      _userCpm = userModel.cpm ?? 200.0;
-    });
-  }
-
-  void _loadScript() async {
-    await _progressService.loadScript(widget.projectId);
-    setState(() {});
-  }
-
-  void _startListening() {
-    _cpmService.start(
-      userAverageCpm: _userCpm,
-      onCpmUpdate: (cpm, status) {
-        if (!mounted) return;
-        setState(() {
-          _currentCpm = cpm;
-          _cpmStatus = status;
-        });
-      },
+    _controller = PresentationPracticeController(
+      projectId: widget.projectId,
+      onUpdate: () => setState(() {}),
     );
-
-    _sttService.startListening((text) {
-      if (!mounted) return;
-      final progress = _progressService.calculateProgressByLastMatch(text);
-      setState(() {
-        _recognizedText = text;
-        _isListening = true;
-        _scriptProgress = progress;
-      });
-      _cpmService.updateRecognizedText(text);
-    });
-  }
-
-  void _stopListening() async {
-    await _sttService.stopListening();
-    _cpmService.stop();
-    if (!mounted) return;
-    setState(() {
-      _isListening = false;
-    });
-  }
-
-  Widget _buildScriptComparisonView() {
-    final scriptChunks = _progressService.scriptChunks;
-    final recognizedWords = _progressService.splitText(_recognizedText);
-
-    List<InlineSpan> scriptSpans = [];
-    List<InlineSpan> recognizedSpans = [];
-
-    for (final scriptWord in scriptChunks) {
-      final isMatched = recognizedWords.any(
-        (w) => _progressService.isSimilar(scriptWord, w),
-      );
-
-      scriptSpans.add(TextSpan(
-        text: '$scriptWord ',
-        style: TextStyle(
-          fontSize: 16,
-          fontWeight: isMatched ? FontWeight.bold : FontWeight.normal,
-          color: isMatched ? Colors.deepPurple : Colors.black,
-        ),
-      ));
-    }
-
-    for (final word in recognizedWords) {
-      recognizedSpans.add(TextSpan(
-        text: '$word ',
-        style: const TextStyle(fontSize: 16, color: Colors.grey),
-      ));
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text(
-          '대본:',
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-        ),
-        RichText(text: TextSpan(children: scriptSpans)),
-        const SizedBox(height: 8),
-        const Text(
-          '인식 결과:',
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-        ),
-        RichText(text: TextSpan(children: recognizedSpans)),
-      ],
-    );
+    _controller.initialize();
   }
 
   @override
   void dispose() {
-    _sttService.stopListening();
-    _cpmService.stop();
+    _controller.dispose();
     super.dispose();
   }
 
@@ -157,21 +49,21 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
           children: [
             ElevatedButton(
               style: ElevatedButton.styleFrom(
-                backgroundColor: _isListening ? Colors.grey : Colors.deepPurple,
+                backgroundColor: _controller.isListening ? Colors.grey : Colors.deepPurple,
                 foregroundColor: Colors.white,
                 padding: const EdgeInsets.symmetric(vertical: 16),
               ),
-              onPressed: _isListening ? _stopListening : _startListening,
-              child: Text(_isListening ? '발표 중지' : '발표 시작'),
+              onPressed: _controller.isListening ? _controller.stopListening : _controller.startListening,
+              child: Text(_controller.isListening ? '발표 중지' : '발표 시작'),
             ),
             const SizedBox(height: 16),
             Text(
-              '현재 CPM: ${_currentCpm.toStringAsFixed(1)} ($_cpmStatus)',
+              '현재 CPM: ${_controller.currentCpm.toStringAsFixed(1)} (${_controller.cpmStatus})',
               style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
             ),
             const SizedBox(height: 8),
             Text(
-              '진행도: ${(_scriptProgress * 100).toStringAsFixed(1)}%',
+              '진행도: ${(_controller.scriptProgress * 100).toStringAsFixed(1)}%',
               style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
             ),
             const SizedBox(height: 24),
@@ -183,7 +75,12 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: SingleChildScrollView(
-                  child: _buildScriptComparisonView(),
+                  child: ScriptComparisonView(
+                    scriptChunks: _controller.scriptChunks,
+                    recognizedText: _controller.recognizedText,
+                    isSimilar: _controller.isSimilar,
+                    splitText: _controller.splitText,
+                  ),
                 ),
               ),
             ),

--- a/app/lib/src/pages/practice_page/presentation_practice_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_practice_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:talk_pilot/src/pages/practice_page/presentation_result_page.dart';
 import 'package:talk_pilot/src/pages/practice_page/widgets/presentation_practice_controller.dart';
+import 'package:talk_pilot/src/pages/practice_page/presentation_result_page.dart';
 import 'widgets/script_comparison_view.dart';
 
 class PresentationPracticePage extends StatefulWidget {
@@ -96,7 +96,14 @@ class _PresentationPracticePageState extends State<PresentationPracticePage> {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (_) => const PresentationResultPage(),
+                    builder:
+                        (_) => PresentationResultPage(
+                          scriptAccuracy:
+                              _controller.scriptAccuracy,
+                          cpmStatus: _controller.cpmStatus,
+                          actualDuration: _controller.presentationDuration,
+                          expectedDuration: _controller.expectedDuration,
+                        ),
                   ),
                 );
               },

--- a/app/lib/src/pages/practice_page/presentation_result_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_result_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:talk_pilot/src/pages/practice_page/widgets/result_summary.dart';
+import 'package:talk_pilot/src/pages/work_page/work_page.dart';
 
 class PresentationResultPage extends StatelessWidget {
   final double scriptAccuracy;
@@ -32,15 +33,38 @@ class PresentationResultPage extends StatelessWidget {
           fontWeight: FontWeight.bold,
         ),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(24),
-        child: ResultSummary(
-          scriptAccuracy: scriptAccuracy,
-          actualCpm: actualCpm,
-          userCpm: userCpm,
-          cpmStatus: cpmStatus,
-          actualDuration: actualDuration,
-          expectedDuration: expectedDuration,
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              ResultSummary(
+                scriptAccuracy: scriptAccuracy,
+                actualCpm: actualCpm,
+                userCpm: userCpm,
+                cpmStatus: cpmStatus,
+                actualDuration: actualDuration,
+                expectedDuration: expectedDuration,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.pushAndRemoveUntil(
+                    context,
+                    MaterialPageRoute(builder: (_) => const WorkPage()),
+                    (route) => false,
+                  );
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.deepPurple,
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+                child: const Text('메인 화면으로 이동'),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/app/lib/src/pages/practice_page/presentation_result_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_result_page.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class PresentationResultPage extends StatelessWidget {
+  const PresentationResultPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('발표 결과'),
+        backgroundColor: Colors.deepPurple,
+        iconTheme: const IconThemeData(color: Colors.white),
+        titleTextStyle: const TextStyle(
+          color: Colors.white,
+          fontSize: 20,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      body: const Center(
+        child: Text(
+          '결과 페이지',
+          style: TextStyle(fontSize: 18, color: Colors.grey),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/src/pages/practice_page/presentation_result_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_result_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:talk_pilot/src/services/practice/score_service.dart';
 
 class PresentationResultPage extends StatelessWidget {
   final double scriptAccuracy;
@@ -22,6 +23,18 @@ class PresentationResultPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final double diffPercent = userCpm == 0 ? 0 : ((actualCpm - userCpm) / userCpm) * 100;
 
+    final scoreService = ScoreService();
+    
+    final double properCpmDurationSeconds = actualDuration.inSeconds * 0.85;
+
+    final double totalScore = scoreService.calculateScore(
+      scriptAccuracy: scriptAccuracy,
+      averageCpmStatus: cpmStatus,
+      properCpmDurationSeconds: properCpmDurationSeconds,
+      actualDuration: actualDuration,
+      expectedDuration: expectedDuration,
+    );
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('발표 결과'),
@@ -42,6 +55,8 @@ class PresentationResultPage extends StatelessWidget {
               '📊 최종 평가',
               style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
             ),
+            const SizedBox(height: 16),
+            Text('⭐ 총점: ${totalScore.toStringAsFixed(1)}점'),
             const SizedBox(height: 16),
             Text('🗣️ 대본 정확도: ${(scriptAccuracy * 100).toStringAsFixed(1)}%'),
             const SizedBox(height: 8),

--- a/app/lib/src/pages/practice_page/presentation_result_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_result_page.dart
@@ -22,9 +22,7 @@ class PresentationResultPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final double diffPercent = userCpm == 0 ? 0 : ((actualCpm - userCpm) / userCpm) * 100;
-
     final scoreService = ScoreService();
-    
     final double properCpmDurationSeconds = actualDuration.inSeconds * 0.85;
 
     final double totalScore = scoreService.calculateScore(
@@ -37,7 +35,7 @@ class PresentationResultPage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('발표 결과'),
+        title: const Text('최종 결과'),
         backgroundColor: Colors.deepPurple,
         iconTheme: const IconThemeData(color: Colors.white),
         titleTextStyle: const TextStyle(
@@ -51,22 +49,49 @@ class PresentationResultPage extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              '📊 최종 평가',
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            Center(
+              child: Text(
+                '${totalScore.toStringAsFixed(1)}점',
+                style: const TextStyle(
+                  fontSize: 48,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.deepPurple,
+                ),
+              ),
             ),
-            const SizedBox(height: 16),
-            Text('⭐ 총점: ${totalScore.toStringAsFixed(1)}점'),
-            const SizedBox(height: 16),
-            Text('🗣️ 대본 정확도: ${(scriptAccuracy * 100).toStringAsFixed(1)}%'),
-            const SizedBox(height: 8),
-            Text('💬 평균 말하기 속도: ${actualCpm.toStringAsFixed(1)} CPM'),
-            Text('🎯 내 기준 속도: ${userCpm.toStringAsFixed(1)} CPM'),
-            Text('📉 속도 차이: ${diffPercent.toStringAsFixed(1)}%'),
-            Text('⏱️ 해석: $cpmStatus'),
-            const SizedBox(height: 16),
-            Text('🕒 발표 시간: ${actualDuration.inSeconds}초'),
-            Text('📌 예상 시간: ${expectedDuration.inSeconds}초'),
+
+            const SizedBox(height: 32),
+
+            _buildResultCard(title: '대본 정확도', value: '${(scriptAccuracy * 100).toStringAsFixed(1)}%'),
+            _buildResultCard(title: '평균 말하기 속도', value: '${actualCpm.toStringAsFixed(1)} CPM'),
+            _buildResultCard(title: '내 기준 속도', value: '${userCpm.toStringAsFixed(1)} CPM'),
+            _buildResultCard(title: '속도 차이', value: '${diffPercent.toStringAsFixed(1)}%'),
+            _buildResultCard(title: '속도 해석', value: cpmStatus),
+            _buildResultCard(title: '발표 시간', value: '${actualDuration.inSeconds}초'),
+            _buildResultCard(title: '예상 시간', value: '${expectedDuration.inSeconds}초'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildResultCard({required String title, required String value}) {
+    return Card(
+      elevation: 1.5,
+      margin: const EdgeInsets.symmetric(vertical: 6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+            ),
+            Text(
+              value,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.black87),
+            ),
           ],
         ),
       ),

--- a/app/lib/src/pages/practice_page/presentation_result_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_result_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:talk_pilot/src/services/practice/score_service.dart';
+import 'package:talk_pilot/src/pages/practice_page/widgets/result_summary.dart';
 
 class PresentationResultPage extends StatelessWidget {
   final double scriptAccuracy;
@@ -21,18 +21,6 @@ class PresentationResultPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double diffPercent = userCpm == 0 ? 0 : ((actualCpm - userCpm) / userCpm) * 100;
-    final scoreService = ScoreService();
-    final double properCpmDurationSeconds = actualDuration.inSeconds * 0.85;
-
-    final double totalScore = scoreService.calculateScore(
-      scriptAccuracy: scriptAccuracy,
-      averageCpmStatus: cpmStatus,
-      properCpmDurationSeconds: properCpmDurationSeconds,
-      actualDuration: actualDuration,
-      expectedDuration: expectedDuration,
-    );
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('최종 결과'),
@@ -46,53 +34,13 @@ class PresentationResultPage extends StatelessWidget {
       ),
       body: Padding(
         padding: const EdgeInsets.all(24),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Center(
-              child: Text(
-                '${totalScore.toStringAsFixed(1)}점',
-                style: const TextStyle(
-                  fontSize: 48,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.deepPurple,
-                ),
-              ),
-            ),
-
-            const SizedBox(height: 32),
-
-            _buildResultCard(title: '대본 정확도', value: '${(scriptAccuracy * 100).toStringAsFixed(1)}%'),
-            _buildResultCard(title: '평균 말하기 속도', value: '${actualCpm.toStringAsFixed(1)} CPM'),
-            _buildResultCard(title: '내 기준 속도', value: '${userCpm.toStringAsFixed(1)} CPM'),
-            _buildResultCard(title: '속도 차이', value: '${diffPercent.toStringAsFixed(1)}%'),
-            _buildResultCard(title: '속도 해석', value: cpmStatus),
-            _buildResultCard(title: '발표 시간', value: '${actualDuration.inSeconds}초'),
-            _buildResultCard(title: '예상 시간', value: '${expectedDuration.inSeconds}초'),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildResultCard({required String title, required String value}) {
-    return Card(
-      elevation: 1.5,
-      margin: const EdgeInsets.symmetric(vertical: 6),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(
-              title,
-              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
-            ),
-            Text(
-              value,
-              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.black87),
-            ),
-          ],
+        child: ResultSummary(
+          scriptAccuracy: scriptAccuracy,
+          actualCpm: actualCpm,
+          userCpm: userCpm,
+          cpmStatus: cpmStatus,
+          actualDuration: actualDuration,
+          expectedDuration: expectedDuration,
         ),
       ),
     );

--- a/app/lib/src/pages/practice_page/presentation_result_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_result_page.dart
@@ -1,7 +1,18 @@
 import 'package:flutter/material.dart';
 
 class PresentationResultPage extends StatelessWidget {
-  const PresentationResultPage({super.key});
+  final double scriptAccuracy;
+  final String cpmStatus;
+  final Duration actualDuration;
+  final Duration expectedDuration;
+
+  const PresentationResultPage({
+    super.key,
+    required this.scriptAccuracy,
+    required this.cpmStatus,
+    required this.actualDuration,
+    required this.expectedDuration,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -16,10 +27,21 @@ class PresentationResultPage extends StatelessWidget {
           fontWeight: FontWeight.bold,
         ),
       ),
-      body: const Center(
-        child: Text(
-          '결과 페이지',
-          style: TextStyle(fontSize: 18, color: Colors.grey),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              '📊 최종 평가',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            Text('🗣️ 대본 정확도: ${(scriptAccuracy * 100).toStringAsFixed(1)}%'),
+            Text('⏱️ 말하기 속도: $cpmStatus'),
+            Text('🕒 발표 시간: ${actualDuration.inSeconds}초'),
+            Text('📌 예상 시간: ${expectedDuration.inSeconds}초'),
+          ],
         ),
       ),
     );

--- a/app/lib/src/pages/practice_page/presentation_result_page.dart
+++ b/app/lib/src/pages/practice_page/presentation_result_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 class PresentationResultPage extends StatelessWidget {
   final double scriptAccuracy;
+  final double actualCpm;
+  final double userCpm;
   final String cpmStatus;
   final Duration actualDuration;
   final Duration expectedDuration;
@@ -9,6 +11,8 @@ class PresentationResultPage extends StatelessWidget {
   const PresentationResultPage({
     super.key,
     required this.scriptAccuracy,
+    required this.actualCpm,
+    required this.userCpm,
     required this.cpmStatus,
     required this.actualDuration,
     required this.expectedDuration,
@@ -16,6 +20,8 @@ class PresentationResultPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final double diffPercent = userCpm == 0 ? 0 : ((actualCpm - userCpm) / userCpm) * 100;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('발표 결과'),
@@ -30,7 +36,7 @@ class PresentationResultPage extends StatelessWidget {
       body: Padding(
         padding: const EdgeInsets.all(24),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const Text(
               '📊 최종 평가',
@@ -38,7 +44,12 @@ class PresentationResultPage extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             Text('🗣️ 대본 정확도: ${(scriptAccuracy * 100).toStringAsFixed(1)}%'),
-            Text('⏱️ 말하기 속도: $cpmStatus'),
+            const SizedBox(height: 8),
+            Text('💬 평균 말하기 속도: ${actualCpm.toStringAsFixed(1)} CPM'),
+            Text('🎯 내 기준 속도: ${userCpm.toStringAsFixed(1)} CPM'),
+            Text('📉 속도 차이: ${diffPercent.toStringAsFixed(1)}%'),
+            Text('⏱️ 해석: $cpmStatus'),
+            const SizedBox(height: 16),
             Text('🕒 발표 시간: ${actualDuration.inSeconds}초'),
             Text('📌 예상 시간: ${expectedDuration.inSeconds}초'),
           ],

--- a/app/lib/src/pages/practice_page/widgets/info_card.dart
+++ b/app/lib/src/pages/practice_page/widgets/info_card.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class InfoCard extends StatelessWidget {
+  final String title;
+  final String value;
+
+  const InfoCard({super.key, required this.title, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 2,
+      color: Colors.white,
+      child: Container(
+        width: 100,
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              value,
+              style: const TextStyle(fontSize: 16, color: Colors.deepPurple),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/src/pages/practice_page/widgets/presentation_practice_controller.dart
+++ b/app/lib/src/pages/practice_page/widgets/presentation_practice_controller.dart
@@ -21,7 +21,7 @@ class PresentationPracticeController {
   String recognizedText = '';
   bool isListening = false;
   double currentCpm = 0.0;
-  String cpmStatus = '';
+  String cpmStatus = '적당함';
   double userCpm = 0.0;
   double scriptProgress = 0.0;
 

--- a/app/lib/src/pages/practice_page/widgets/presentation_practice_controller.dart
+++ b/app/lib/src/pages/practice_page/widgets/presentation_practice_controller.dart
@@ -1,0 +1,86 @@
+import 'dart:ui';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:talk_pilot/src/services/stt/stt_service.dart';
+import 'package:talk_pilot/src/services/practice/live_cpm_service.dart';
+import 'package:talk_pilot/src/services/database/user_service.dart';
+import 'package:talk_pilot/src/services/practice/script_progress_service.dart';
+
+class PresentationPracticeController {
+  final String projectId;
+  final VoidCallback onUpdate;
+
+  final SttService _sttService = SttService();
+  final LiveCpmService _cpmService = LiveCpmService();
+  final ScriptProgressService _progressService = ScriptProgressService();
+
+  String recognizedText = '';
+  bool isListening = false;
+  double currentCpm = 0.0;
+  String cpmStatus = '';
+  double userCpm = 0.0;
+  double scriptProgress = 0.0;
+
+  List<String> get scriptChunks => _progressService.scriptChunks;
+
+  PresentationPracticeController({
+    required this.projectId,
+    required this.onUpdate,
+  });
+
+  Future<void> initialize() async {
+    _sttService.init();
+    await _loadUserCpm();
+    await _loadScript();
+  }
+
+  Future<void> _loadUserCpm() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+
+    final userModel = await UserService().readUser(user.uid);
+    if (userModel == null) return;
+
+    userCpm = userModel.cpm ?? 200.0;
+    onUpdate();
+  }
+
+  Future<void> _loadScript() async {
+    await _progressService.loadScript(projectId);
+    onUpdate();
+  }
+
+  void startListening() {
+    _cpmService.start(
+      userAverageCpm: userCpm,
+      onCpmUpdate: (cpm, status) {
+        currentCpm = cpm;
+        cpmStatus = status;
+        onUpdate();
+      },
+    );
+
+    _sttService.startListening((text) {
+      recognizedText = text;
+      isListening = true;
+      scriptProgress = _progressService.calculateProgressByLastMatch(text);
+      _cpmService.updateRecognizedText(text);
+      onUpdate();
+    });
+  }
+
+  Future<void> stopListening() async {
+    await _sttService.stopListening();
+    _cpmService.stop();
+    isListening = false;
+    onUpdate();
+  }
+
+  void dispose() {
+    _sttService.stopListening();
+    _cpmService.stop();
+  }
+
+  bool isSimilar(String a, String b) => _progressService.isSimilar(a, b);
+  List<String> splitText(String text) => _progressService.splitText(text);
+}

--- a/app/lib/src/pages/practice_page/widgets/presentation_practice_controller.dart
+++ b/app/lib/src/pages/practice_page/widgets/presentation_practice_controller.dart
@@ -1,10 +1,12 @@
 import 'dart:ui';
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:talk_pilot/src/models/project_model.dart';
 import 'package:talk_pilot/src/services/stt/stt_service.dart';
 import 'package:talk_pilot/src/services/practice/live_cpm_service.dart';
 import 'package:talk_pilot/src/services/database/user_service.dart';
 import 'package:talk_pilot/src/services/practice/script_progress_service.dart';
+import 'package:talk_pilot/src/services/database/project_service.dart';
 
 class PresentationPracticeController {
   final String projectId;
@@ -13,6 +15,8 @@ class PresentationPracticeController {
   final SttService _sttService = SttService();
   final LiveCpmService _cpmService = LiveCpmService();
   final ScriptProgressService _progressService = ScriptProgressService();
+  final ProjectService _projectService = ProjectService();
+  final Stopwatch _stopwatch = Stopwatch();
 
   String recognizedText = '';
   bool isListening = false;
@@ -21,7 +25,12 @@ class PresentationPracticeController {
   double userCpm = 0.0;
   double scriptProgress = 0.0;
 
+  ProjectModel? _projectModel;
+
   List<String> get scriptChunks => _progressService.scriptChunks;
+  Duration get presentationDuration => _stopwatch.elapsed;
+  Duration get expectedDuration => Duration(seconds: _projectModel?.estimatedTime ?? 120);
+  double get scriptAccuracy => _progressService.calculateAccuracy(recognizedText);
 
   PresentationPracticeController({
     required this.projectId,
@@ -46,11 +55,15 @@ class PresentationPracticeController {
   }
 
   Future<void> _loadScript() async {
+    _projectModel = await _projectService.readProject(projectId);
     await _progressService.loadScript(projectId);
     onUpdate();
   }
 
   void startListening() {
+    _stopwatch.reset();
+    _stopwatch.start();
+
     _cpmService.start(
       userAverageCpm: userCpm,
       onCpmUpdate: (cpm, status) {
@@ -70,6 +83,7 @@ class PresentationPracticeController {
   }
 
   Future<void> stopListening() async {
+    _stopwatch.stop();
     await _sttService.stopListening();
     _cpmService.stop();
     isListening = false;

--- a/app/lib/src/pages/practice_page/widgets/result_button.dart
+++ b/app/lib/src/pages/practice_page/widgets/result_button.dart
@@ -4,6 +4,8 @@ import 'package:talk_pilot/src/pages/practice_page/presentation_result_page.dart
 class ResultButton extends StatelessWidget {
   final double progress;
   final double accuracy;
+  final double userCpm;
+  final double actualCpm;
   final String cpmStatus;
   final Duration actualDuration;
   final Duration expectedDuration;
@@ -12,6 +14,8 @@ class ResultButton extends StatelessWidget {
     super.key,
     required this.progress,
     required this.accuracy,
+    required this.userCpm,
+    required this.actualCpm,
     required this.cpmStatus,
     required this.actualDuration,
     required this.expectedDuration,
@@ -29,6 +33,8 @@ class ResultButton extends StatelessWidget {
                 MaterialPageRoute(
                   builder: (_) => PresentationResultPage(
                     scriptAccuracy: accuracy,
+                    actualCpm: actualCpm,
+                    userCpm: userCpm,
                     cpmStatus: cpmStatus,
                     actualDuration: actualDuration,
                     expectedDuration: expectedDuration,

--- a/app/lib/src/pages/practice_page/widgets/result_button.dart
+++ b/app/lib/src/pages/practice_page/widgets/result_button.dart
@@ -25,26 +25,26 @@ class ResultButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final bool isProgressEnough = progress >= 0.9;
 
+    if (!isProgressEnough) return const SizedBox.shrink(); 
+
     return ElevatedButton(
-      onPressed: isProgressEnough
-          ? () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => PresentationResultPage(
-                    scriptAccuracy: accuracy,
-                    actualCpm: actualCpm,
-                    userCpm: userCpm,
-                    cpmStatus: cpmStatus,
-                    actualDuration: actualDuration,
-                    expectedDuration: expectedDuration,
-                  ),
-                ),
-              );
-            }
-          : null,
+      onPressed: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => PresentationResultPage(
+              scriptAccuracy: accuracy,
+              actualCpm: actualCpm,
+              userCpm: userCpm,
+              cpmStatus: cpmStatus,
+              actualDuration: actualDuration,
+              expectedDuration: expectedDuration,
+            ),
+          ),
+        );
+      },
       style: ElevatedButton.styleFrom(
-        backgroundColor: isProgressEnough ? Colors.deepPurple : Colors.grey,
+        backgroundColor: Colors.deepPurple,
         foregroundColor: Colors.white,
         padding: const EdgeInsets.symmetric(vertical: 16),
       ),

--- a/app/lib/src/pages/practice_page/widgets/result_button.dart
+++ b/app/lib/src/pages/practice_page/widgets/result_button.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:talk_pilot/src/pages/practice_page/presentation_result_page.dart';
+
+class ResultButton extends StatelessWidget {
+  final double progress;
+  final double accuracy;
+  final String cpmStatus;
+  final Duration actualDuration;
+  final Duration expectedDuration;
+
+  const ResultButton({
+    super.key,
+    required this.progress,
+    required this.accuracy,
+    required this.cpmStatus,
+    required this.actualDuration,
+    required this.expectedDuration,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isProgressEnough = progress >= 0.9;
+
+    return ElevatedButton(
+      onPressed: isProgressEnough
+          ? () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => PresentationResultPage(
+                    scriptAccuracy: accuracy,
+                    cpmStatus: cpmStatus,
+                    actualDuration: actualDuration,
+                    expectedDuration: expectedDuration,
+                  ),
+                ),
+              );
+            }
+          : null,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: isProgressEnough ? Colors.deepPurple : Colors.grey,
+        foregroundColor: Colors.white,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+      ),
+      child: const Text('결과 보러 가기'),
+    );
+  }
+}

--- a/app/lib/src/pages/practice_page/widgets/result_summary.dart
+++ b/app/lib/src/pages/practice_page/widgets/result_summary.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:talk_pilot/src/services/database/user_service.dart';
+import 'package:talk_pilot/src/services/practice/score_service.dart';
+
+class ResultSummary extends StatefulWidget {
+  final double scriptAccuracy;
+  final double actualCpm;
+  final double userCpm;
+  final String cpmStatus;
+  final Duration actualDuration;
+  final Duration expectedDuration;
+
+  const ResultSummary({
+    super.key,
+    required this.scriptAccuracy,
+    required this.actualCpm,
+    required this.userCpm,
+    required this.cpmStatus,
+    required this.actualDuration,
+    required this.expectedDuration,
+  });
+
+  @override
+  State<ResultSummary> createState() => _ResultSummaryState();
+}
+
+class _ResultSummaryState extends State<ResultSummary> {
+  double targetScore = 90.0;
+  bool isLoading = true;
+
+  late final double totalScore;
+
+  @override
+  void initState() {
+    super.initState();
+
+    final scoreService = ScoreService();
+    final properCpmDurationSeconds = widget.actualDuration.inSeconds * 0.85;
+    totalScore = scoreService.calculateScore(
+      scriptAccuracy: widget.scriptAccuracy,
+      averageCpmStatus: widget.cpmStatus,
+      properCpmDurationSeconds: properCpmDurationSeconds,
+      actualDuration: widget.actualDuration,
+      expectedDuration: widget.expectedDuration,
+    );
+
+    _loadUserTargetScore();
+  }
+
+  Future<void> _loadUserTargetScore() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+
+    final userModel = await UserService().readUser(user.uid);
+    if (userModel != null) {
+      setState(() {
+        targetScore = userModel.targetScore ?? 90.0;
+      });
+    }
+
+    setState(() {
+      isLoading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final diffPercent = widget.userCpm == 0
+        ? 0
+        : ((widget.actualCpm - widget.userCpm) / widget.userCpm) * 100;
+
+    if (isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Center(
+          child: Text(
+            '${totalScore.toStringAsFixed(1)}점',
+            style: const TextStyle(
+              fontSize: 48,
+              fontWeight: FontWeight.bold,
+              color: Colors.deepPurple,
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Center(
+          child: Text(
+            totalScore >= targetScore
+                ? '목표 점수를 넘었습니다.'
+                : '목표 점수를 넘지 못했습니다.',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+              color: totalScore >= targetScore
+                  ? Colors.green
+                  : Colors.redAccent,
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Center(
+          child: Text(
+            '목표 점수: ${targetScore.toStringAsFixed(1)}점',
+            style: const TextStyle(
+              fontSize: 14,
+              color: Colors.grey,
+            ),
+          ),
+        ),
+        const SizedBox(height: 32),
+        _buildResultCard(title: '대본 정확도', value: '${(widget.scriptAccuracy * 100).toStringAsFixed(1)}%'),
+        _buildResultCard(title: '평균 말하기 속도', value: '${widget.actualCpm.toStringAsFixed(1)} CPM'),
+        _buildResultCard(title: '내 기준 속도', value: '${widget.userCpm.toStringAsFixed(1)} CPM'),
+        _buildResultCard(title: '속도 차이', value: '${diffPercent.toStringAsFixed(1)}%'),
+        _buildResultCard(title: '속도 해석', value: widget.cpmStatus),
+        _buildResultCard(title: '발표 시간', value: '${widget.actualDuration.inSeconds}초'),
+        _buildResultCard(title: '예상 시간', value: '${widget.expectedDuration.inSeconds}초'),
+      ],
+    );
+  }
+
+  Widget _buildResultCard({required String title, required String value}) {
+    return Card(
+      elevation: 1.5,
+      margin: const EdgeInsets.symmetric(vertical: 6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(title, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500)),
+            Text(value, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.black87)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
+++ b/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
@@ -18,19 +18,21 @@ class ScriptComparisonView extends StatelessWidget {
   Widget build(BuildContext context) {
     final recognizedWords = splitText(recognizedText);
     final matchedFlags = List<bool>.filled(scriptChunks.length, false);
-    final usedScriptIndexes = <int>{};
+    final usedRecognizedIndexes = <int>{};
 
-    for (int i = 0; i < recognizedWords.length; i++) {
-      final word = recognizedWords[i];
-      final start = (i - 10).clamp(0, scriptChunks.length);
-      final end = (i + 10).clamp(0, scriptChunks.length);
+    int lastMatchedRecognizedIndex = -1;
+
+    for (int i = 0; i < scriptChunks.length; i++) {
+      final start = (lastMatchedRecognizedIndex + 1 - 10).clamp(0, recognizedWords.length);
+      final end = (lastMatchedRecognizedIndex + 1 + 10).clamp(0, recognizedWords.length);
 
       for (int j = start; j < end; j++) {
-        if (usedScriptIndexes.contains(j)) continue;
+        if (usedRecognizedIndexes.contains(j)) continue;
 
-        if (isSimilar(scriptChunks[j], word)) {
-          matchedFlags[j] = true;
-          usedScriptIndexes.add(j);
+        if (isSimilar(scriptChunks[i], recognizedWords[j])) {
+          matchedFlags[i] = true;
+          usedRecognizedIndexes.add(j);
+          lastMatchedRecognizedIndex = j;
           break;
         }
       }

--- a/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
+++ b/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
@@ -17,19 +17,35 @@ class ScriptComparisonView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final recognizedWords = splitText(recognizedText);
+    final matchedFlags = List<bool>.filled(scriptChunks.length, false);
 
-    List<InlineSpan> scriptSpans = scriptChunks.map((scriptWord) {
-      final matched = recognizedWords.any((w) => isSimilar(scriptWord, w));
+    int scriptIndex = 0;
+    int recognizedIndex = 0;
+
+    while (scriptIndex < scriptChunks.length && recognizedIndex < recognizedWords.length) {
+      if (isSimilar(scriptChunks[scriptIndex], recognizedWords[recognizedIndex])) {
+        matchedFlags[scriptIndex] = true;
+        recognizedIndex++;
+        scriptIndex++;
+      } else {
+        scriptIndex++;
+      }
+    }
+
+    List<InlineSpan> scriptSpans = List.generate(scriptChunks.length, (i) {
+      final word = scriptChunks[i];
+      final matched = matchedFlags[i];
       return TextSpan(
-        text: '$scriptWord ',
+        text: '$word ',
         style: TextStyle(
           fontSize: 16,
           fontWeight: matched ? FontWeight.bold : FontWeight.normal,
           color: matched ? Colors.deepPurple : Colors.black,
         ),
       );
-    }).toList();
+    });
 
+    // 인식된 텍스트는 기존처럼 그대로 회색으로 출력
     List<InlineSpan> recognizedSpans = recognizedWords.map((word) {
       return TextSpan(
         text: '$word ',

--- a/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
+++ b/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
@@ -18,15 +18,20 @@ class ScriptComparisonView extends StatelessWidget {
   Widget build(BuildContext context) {
     final recognizedWords = splitText(recognizedText);
     final matchedFlags = List<bool>.filled(scriptChunks.length, false);
-    final usedRecognizedIndexes = <int>{};
+    final usedScriptIndexes = <int>{};
 
-    for (int i = 0; i < scriptChunks.length; i++) {
-      for (int j = 0; j < recognizedWords.length; j++) {
-        if (usedRecognizedIndexes.contains(j)) continue;
+    for (int i = 0; i < recognizedWords.length; i++) {
+      final word = recognizedWords[i];
 
-        if (isSimilar(scriptChunks[i], recognizedWords[j])) {
-          matchedFlags[i] = true;
-          usedRecognizedIndexes.add(j);
+      final start = (i - 10).clamp(0, scriptChunks.length);
+      final end = (i + 10).clamp(0, scriptChunks.length);
+
+      for (int j = start; j < end; j++) {
+        if (usedScriptIndexes.contains(j)) continue;
+
+        if (isSimilar(scriptChunks[j], word)) {
+          matchedFlags[j] = true;
+          usedScriptIndexes.add(j);
           break;
         }
       }

--- a/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
+++ b/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
@@ -32,7 +32,7 @@ class ScriptComparisonView extends StatelessWidget {
       }
     }
 
-    List<InlineSpan> scriptSpans = List.generate(scriptChunks.length, (i) {
+    final scriptSpans = List<InlineSpan>.generate(scriptChunks.length, (i) {
       final word = scriptChunks[i];
       final matched = matchedFlags[i];
       return TextSpan(
@@ -45,29 +45,6 @@ class ScriptComparisonView extends StatelessWidget {
       );
     });
 
-    List<InlineSpan> recognizedSpans =
-        recognizedWords.map((word) {
-          return TextSpan(
-            text: '$word ',
-            style: const TextStyle(fontSize: 16, color: Colors.grey),
-          );
-        }).toList();
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text(
-          '대본:',
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-        ),
-        RichText(text: TextSpan(children: scriptSpans)),
-        const SizedBox(height: 8),
-        const Text(
-          '인식 결과:',
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-        ),
-        RichText(text: TextSpan(children: recognizedSpans)),
-      ],
-    );
+    return RichText(text: TextSpan(children: scriptSpans));
   }
 }

--- a/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
+++ b/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
@@ -22,7 +22,6 @@ class ScriptComparisonView extends StatelessWidget {
 
     for (int i = 0; i < recognizedWords.length; i++) {
       final word = recognizedWords[i];
-
       final start = (i - 10).clamp(0, scriptChunks.length);
       final end = (i + 10).clamp(0, scriptChunks.length);
 

--- a/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
+++ b/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
@@ -18,17 +18,17 @@ class ScriptComparisonView extends StatelessWidget {
   Widget build(BuildContext context) {
     final recognizedWords = splitText(recognizedText);
     final matchedFlags = List<bool>.filled(scriptChunks.length, false);
+    final usedRecognizedIndexes = <int>{};
 
-    int scriptIndex = 0;
-    int recognizedIndex = 0;
+    for (int i = 0; i < scriptChunks.length; i++) {
+      for (int j = 0; j < recognizedWords.length; j++) {
+        if (usedRecognizedIndexes.contains(j)) continue;
 
-    while (scriptIndex < scriptChunks.length && recognizedIndex < recognizedWords.length) {
-      if (isSimilar(scriptChunks[scriptIndex], recognizedWords[recognizedIndex])) {
-        matchedFlags[scriptIndex] = true;
-        recognizedIndex++;
-        scriptIndex++;
-      } else {
-        scriptIndex++;
+        if (isSimilar(scriptChunks[i], recognizedWords[j])) {
+          matchedFlags[i] = true;
+          usedRecognizedIndexes.add(j);
+          break;
+        }
       }
     }
 
@@ -45,13 +45,13 @@ class ScriptComparisonView extends StatelessWidget {
       );
     });
 
-    // 인식된 텍스트는 기존처럼 그대로 회색으로 출력
-    List<InlineSpan> recognizedSpans = recognizedWords.map((word) {
-      return TextSpan(
-        text: '$word ',
-        style: const TextStyle(fontSize: 16, color: Colors.grey),
-      );
-    }).toList();
+    List<InlineSpan> recognizedSpans =
+        recognizedWords.map((word) {
+          return TextSpan(
+            text: '$word ',
+            style: const TextStyle(fontSize: 16, color: Colors.grey),
+          );
+        }).toList();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
+++ b/app/lib/src/pages/practice_page/widgets/script_comparison_view.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class ScriptComparisonView extends StatelessWidget {
+  final List<String> scriptChunks;
+  final String recognizedText;
+  final bool Function(String, String) isSimilar;
+  final List<String> Function(String) splitText;
+
+  const ScriptComparisonView({
+    super.key,
+    required this.scriptChunks,
+    required this.recognizedText,
+    required this.isSimilar,
+    required this.splitText,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final recognizedWords = splitText(recognizedText);
+
+    List<InlineSpan> scriptSpans = scriptChunks.map((scriptWord) {
+      final matched = recognizedWords.any((w) => isSimilar(scriptWord, w));
+      return TextSpan(
+        text: '$scriptWord ',
+        style: TextStyle(
+          fontSize: 16,
+          fontWeight: matched ? FontWeight.bold : FontWeight.normal,
+          color: matched ? Colors.deepPurple : Colors.black,
+        ),
+      );
+    }).toList();
+
+    List<InlineSpan> recognizedSpans = recognizedWords.map((word) {
+      return TextSpan(
+        text: '$word ',
+        style: const TextStyle(fontSize: 16, color: Colors.grey),
+      );
+    }).toList();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '대본:',
+          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+        ),
+        RichText(text: TextSpan(children: scriptSpans)),
+        const SizedBox(height: 8),
+        const Text(
+          '인식 결과:',
+          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+        ),
+        RichText(text: TextSpan(children: recognizedSpans)),
+      ],
+    );
+  }
+}

--- a/app/lib/src/pages/project_page/project_detail_page.dart
+++ b/app/lib/src/pages/project_page/project_detail_page.dart
@@ -4,9 +4,11 @@ import 'package:provider/provider.dart';
 import 'package:talk_pilot/src/models/project_model.dart';
 import 'package:talk_pilot/src/provider/user_provider.dart';
 import 'package:talk_pilot/src/components/loading_indicator.dart';
+import 'package:talk_pilot/src/components/toast_message.dart';
 
 import 'package:talk_pilot/src/services/database/project_service.dart';
 import 'package:talk_pilot/src/services/database/project_stream_service.dart';
+import 'package:talk_pilot/src/services/database/user_service.dart';
 import 'package:talk_pilot/src/pages/project_page/widgets/project_info_card.dart';
 import 'package:talk_pilot/src/pages/project_page/widgets/script_upload_button.dart';
 import 'package:talk_pilot/src/pages/project_page/widgets/editable/editable_text_editor.dart';
@@ -125,13 +127,29 @@ class _ProjectDetailPageState extends State<ProjectDetailPage> {
                   backgroundColor: Colors.deepPurple,
                   foregroundColor: Colors.white,
                   padding: const EdgeInsets.symmetric(vertical: 16),
-                  textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                  textStyle: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
-                onPressed: () {
+                onPressed: () async {
+                  final user = context.read<UserProvider>().currentUser;
+                  if (user == null) return;
+
+                  final userModel = await UserService().readUser(user.uid);
+                  final userCpm = userModel?.cpm;
+
+                  if (userCpm == 0 || userCpm == null) {
+                    ToastMessage.show("CPM 측정을 먼저 완료해주세요.");
+                    return;
+                  }
+
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (_) => PresentationPracticePage(projectId: project.id),
+                      builder:
+                          (_) =>
+                              PresentationPracticePage(projectId: project.id),
                     ),
                   );
                 },

--- a/app/lib/src/pages/project_page/project_detail_page.dart
+++ b/app/lib/src/pages/project_page/project_detail_page.dart
@@ -4,7 +4,6 @@ import 'package:provider/provider.dart';
 import 'package:talk_pilot/src/models/project_model.dart';
 import 'package:talk_pilot/src/provider/user_provider.dart';
 import 'package:talk_pilot/src/components/loading_indicator.dart';
-import 'package:talk_pilot/src/components/toast_message.dart';
 
 import 'package:talk_pilot/src/services/database/project_service.dart';
 import 'package:talk_pilot/src/services/database/project_stream_service.dart';
@@ -13,6 +12,8 @@ import 'package:talk_pilot/src/pages/project_page/widgets/project_info_card.dart
 import 'package:talk_pilot/src/pages/project_page/widgets/script_upload_button.dart';
 import 'package:talk_pilot/src/pages/project_page/widgets/editable/editable_text_editor.dart';
 import 'package:talk_pilot/src/pages/practice_page/presentation_practice_page.dart';
+import 'package:talk_pilot/src/pages/profile_page/cpm_calculate_page.dart';
+
 
 class ProjectDetailPage extends StatefulWidget {
   final String projectId;
@@ -139,8 +140,35 @@ class _ProjectDetailPageState extends State<ProjectDetailPage> {
                   final userModel = await UserService().readUser(user.uid);
                   final userCpm = userModel?.cpm;
 
-                  if (userCpm == 0 || userCpm == null) {
-                    ToastMessage.show("CPM 측정을 먼저 완료해주세요.");
+                  if (userCpm == null || userCpm == 0.0) {
+                    showDialog(
+                      context: context,
+                      builder:
+                          (context) => AlertDialog(
+                            title: const Text('CPM 정보가 없습니다'),
+                            content: const Text(
+                              '발표 연습을 시작하기 전에\nCPM을 먼저 측정해주세요.',
+                            ),
+                            actions: [
+                              TextButton(
+                                onPressed: () => Navigator.pop(context),
+                                child: const Text('취소'),
+                              ),
+                              TextButton(
+                                onPressed: () {
+                                  Navigator.pop(context); // 다이얼로그 닫기
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (_) => const CpmCalculatePage(),
+                                    ),
+                                  );
+                                },
+                                child: const Text('측정하러 가기'),
+                              ),
+                            ],
+                          ),
+                    );
                     return;
                   }
 

--- a/app/lib/src/pages/project_page/project_detail_page.dart
+++ b/app/lib/src/pages/project_page/project_detail_page.dart
@@ -7,10 +7,10 @@ import 'package:talk_pilot/src/components/loading_indicator.dart';
 
 import 'package:talk_pilot/src/services/database/project_service.dart';
 import 'package:talk_pilot/src/services/database/project_stream_service.dart';
-
 import 'package:talk_pilot/src/pages/project_page/widgets/project_info_card.dart';
 import 'package:talk_pilot/src/pages/project_page/widgets/script_upload_button.dart';
 import 'package:talk_pilot/src/pages/project_page/widgets/editable/editable_text_editor.dart';
+import 'package:talk_pilot/src/pages/practice_page/presentation_practice_page.dart';
 
 class ProjectDetailPage extends StatefulWidget {
   final String projectId;
@@ -118,6 +118,25 @@ class _ProjectDetailPageState extends State<ProjectDetailPage> {
                   editable: isEditable,
                 ),
               ].expand((widget) => [widget, const SizedBox(height: 16)]),
+
+              const SizedBox(height: 24),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.deepPurple,
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => PresentationPracticePage(projectId: project.id),
+                    ),
+                  );
+                },
+                child: const Text('발표 연습 시작'),
+              ),
             ],
           ),
         );

--- a/app/lib/src/pages/project_page/project_detail_page.dart
+++ b/app/lib/src/pages/project_page/project_detail_page.dart
@@ -4,16 +4,12 @@ import 'package:provider/provider.dart';
 import 'package:talk_pilot/src/models/project_model.dart';
 import 'package:talk_pilot/src/provider/user_provider.dart';
 import 'package:talk_pilot/src/components/loading_indicator.dart';
-
 import 'package:talk_pilot/src/services/database/project_service.dart';
 import 'package:talk_pilot/src/services/database/project_stream_service.dart';
-import 'package:talk_pilot/src/services/database/user_service.dart';
 import 'package:talk_pilot/src/pages/project_page/widgets/project_info_card.dart';
 import 'package:talk_pilot/src/pages/project_page/widgets/script_upload_button.dart';
 import 'package:talk_pilot/src/pages/project_page/widgets/editable/editable_text_editor.dart';
-import 'package:talk_pilot/src/pages/practice_page/presentation_practice_page.dart';
-import 'package:talk_pilot/src/pages/profile_page/cpm_calculate_page.dart';
-
+import 'package:talk_pilot/src/pages/project_page/widgets/practice_button.dart';
 
 class ProjectDetailPage extends StatefulWidget {
   final String projectId;
@@ -121,68 +117,9 @@ class _ProjectDetailPageState extends State<ProjectDetailPage> {
                   editable: isEditable,
                 ),
               ].expand((widget) => [widget, const SizedBox(height: 16)]),
-
               const SizedBox(height: 24),
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.deepPurple,
-                  foregroundColor: Colors.white,
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  textStyle: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                onPressed: () async {
-                  final user = context.read<UserProvider>().currentUser;
-                  if (user == null) return;
 
-                  final userModel = await UserService().readUser(user.uid);
-                  final userCpm = userModel?.cpm;
-
-                  if (userCpm == null || userCpm == 0.0) {
-                    showDialog(
-                      context: context,
-                      builder:
-                          (context) => AlertDialog(
-                            title: const Text('CPM 정보가 없습니다'),
-                            content: const Text(
-                              '발표 연습을 시작하기 전에\nCPM을 먼저 측정해주세요.',
-                            ),
-                            actions: [
-                              TextButton(
-                                onPressed: () => Navigator.pop(context),
-                                child: const Text('취소'),
-                              ),
-                              TextButton(
-                                onPressed: () {
-                                  Navigator.pop(context); // 다이얼로그 닫기
-                                  Navigator.push(
-                                    context,
-                                    MaterialPageRoute(
-                                      builder: (_) => const CpmCalculatePage(),
-                                    ),
-                                  );
-                                },
-                                child: const Text('측정하러 가기'),
-                              ),
-                            ],
-                          ),
-                    );
-                    return;
-                  }
-
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder:
-                          (_) =>
-                              PresentationPracticePage(projectId: project.id),
-                    ),
-                  );
-                },
-                child: const Text('발표 연습 시작'),
-              ),
+              PracticeButton(project: project),
             ],
           ),
         );

--- a/app/lib/src/pages/project_page/widgets/practice_button.dart
+++ b/app/lib/src/pages/project_page/widgets/practice_button.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:talk_pilot/src/models/project_model.dart';
+import 'package:talk_pilot/src/pages/profile_page/cpm_calculate_page.dart';
+import 'package:talk_pilot/src/pages/practice_page/presentation_practice_page.dart';
+import 'package:talk_pilot/src/provider/user_provider.dart';
+import 'package:talk_pilot/src/services/database/user_service.dart';
+
+class PracticeButton extends StatelessWidget {
+  final ProjectModel project;
+
+  const PracticeButton({super.key, required this.project});
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: Colors.deepPurple,
+        foregroundColor: Colors.white,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+      ),
+      onPressed: () async {
+        final user = context.read<UserProvider>().currentUser;
+        if (user == null) return;
+
+        final userModel = await UserService().readUser(user.uid);
+        final userCpm = userModel?.cpm;
+
+        if (userCpm == null || userCpm == 0.0) {
+          showDialog(
+            context: context,
+            builder: (context) => AlertDialog(
+              title: const Text('CPM 정보가 없습니다'),
+              content: const Text(
+                '발표 연습을 시작하기 전에\nCPM을 먼저 측정해주세요.',
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('취소'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const CpmCalculatePage(),
+                      ),
+                    );
+                  },
+                  child: const Text('측정하러 가기'),
+                ),
+              ],
+            ),
+          );
+          return;
+        }
+
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) =>
+                PresentationPracticePage(projectId: project.id),
+          ),
+        );
+      },
+      child: const Text('발표 연습 시작'),
+    );
+  }
+}

--- a/app/lib/src/services/practice/live_cpm_service.dart
+++ b/app/lib/src/services/practice/live_cpm_service.dart
@@ -4,10 +4,15 @@ class LiveCpmService {
   final Stopwatch _stopwatch = Stopwatch();
   Timer? _timer;
   int _totalCharacters = 0;
+  double _userAverageCpm = 0.0;
 
-  Function(double cpm)? _onCpmUpdate;
+  Function(double cpm, String status)? _onCpmUpdate;
 
-  void start({required Function(double cpm) onCpmUpdate}) {
+  void start({
+    required double userAverageCpm,
+    required Function(double cpm, String status) onCpmUpdate,
+  }) {
+    _userAverageCpm = userAverageCpm;
     _onCpmUpdate = onCpmUpdate;
     _totalCharacters = 0;
     _stopwatch.reset();
@@ -15,9 +20,10 @@ class LiveCpmService {
 
     _timer = Timer.periodic(const Duration(seconds: 1), (_) {
       final minutes = _stopwatch.elapsed.inSeconds / 60;
-      if (minutes > 0) {
+      if (minutes > 0.1) {
         final cpm = _totalCharacters / minutes;
-        _onCpmUpdate?.call(cpm);
+        final status = _getCpmStatus(_userAverageCpm, cpm);
+        _onCpmUpdate?.call(cpm, status);
       }
     });
   }
@@ -37,5 +43,11 @@ class LiveCpmService {
     stop();
     _totalCharacters = 0;
     _stopwatch.reset();
+  }
+
+  String _getCpmStatus(double userCpm, double currentCpm) {
+    if (currentCpm < userCpm * 0.7) return '느림';
+    if (currentCpm > userCpm * 1.3) return '빠름';
+    return '적당함';
   }
 }

--- a/app/lib/src/services/practice/live_cpm_service.dart
+++ b/app/lib/src/services/practice/live_cpm_service.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+
+class LiveCpmService {
+  final Stopwatch _stopwatch = Stopwatch();
+  Timer? _timer;
+  int _totalCharacters = 0;
+
+  Function(double cpm)? _onCpmUpdate;
+
+  void start({required Function(double cpm) onCpmUpdate}) {
+    _onCpmUpdate = onCpmUpdate;
+    _totalCharacters = 0;
+    _stopwatch.reset();
+    _stopwatch.start();
+
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      final minutes = _stopwatch.elapsed.inSeconds / 60;
+      if (minutes > 0) {
+        final cpm = _totalCharacters / minutes;
+        _onCpmUpdate?.call(cpm);
+      }
+    });
+  }
+
+  void updateRecognizedText(String text) {
+    _totalCharacters = text.replaceAll(' ', '').length;
+  }
+
+  void stop() {
+    _stopwatch.stop();
+    _timer?.cancel();
+    _timer = null;
+    _onCpmUpdate = null;
+  }
+
+  void reset() {
+    stop();
+    _totalCharacters = 0;
+    _stopwatch.reset();
+  }
+}

--- a/app/lib/src/services/practice/score_service.dart
+++ b/app/lib/src/services/practice/score_service.dart
@@ -1,0 +1,34 @@
+import 'dart:math';
+
+class ScoreService {
+  double calculateScore({
+    required double scriptAccuracy, 
+    required String cpmStatus,   
+    required Duration actualDuration,
+    required Duration expectedDuration,
+  }) {
+    final scriptScore = (scriptAccuracy * 50).clamp(0, 50);
+
+    double speedScore = switch (cpmStatus) {
+      '적당함' => 25,
+      '느림' || '빠름' => 15,
+      _ => 0,
+    };
+
+    final lowerBound = expectedDuration.inSeconds * 0.85;
+    final upperBound = expectedDuration.inSeconds * 1.15;
+    final actualSec = actualDuration.inSeconds;
+
+    final timeScore = (actualSec >= lowerBound && actualSec <= upperBound) ? 25 : 15;
+
+    return min(scriptScore + speedScore + timeScore, 100);
+  }
+
+  String getGrade(double score) {
+    if (score >= 90) return 'A';
+    if (score >= 80) return 'B';
+    if (score >= 70) return 'C';
+    if (score >= 60) return 'D';
+    return 'F';
+  }
+}

--- a/app/lib/src/services/practice/score_service.dart
+++ b/app/lib/src/services/practice/score_service.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 class ScoreService {
   double calculateScore({
     required double scriptAccuracy,

--- a/app/lib/src/services/practice/score_service.dart
+++ b/app/lib/src/services/practice/score_service.dart
@@ -2,33 +2,32 @@ import 'dart:math';
 
 class ScoreService {
   double calculateScore({
-    required double scriptAccuracy, 
-    required String cpmStatus,   
+    required double scriptAccuracy,
+    required String averageCpmStatus,
+    required double properCpmDurationSeconds,
     required Duration actualDuration,
     required Duration expectedDuration,
   }) {
-    final scriptScore = (scriptAccuracy * 50).clamp(0, 50);
+    final accuracyScore = (scriptAccuracy * 20).clamp(0, 20);
 
-    double speedScore = switch (cpmStatus) {
-      '적당함' => 25,
-      '느림' || '빠름' => 15,
-      _ => 0,
+    final double avgCpmScore = switch (averageCpmStatus) {
+      '적당함' => 25.0,
+      '느림' || '빠름' => 15.0,
+      _ => 5.0,
     };
 
-    final lowerBound = expectedDuration.inSeconds * 0.85;
-    final upperBound = expectedDuration.inSeconds * 1.15;
-    final actualSec = actualDuration.inSeconds;
+    final totalSec = actualDuration.inSeconds.toDouble();
+    final ratio = (properCpmDurationSeconds / totalSec).clamp(0.0, 1.0);
+    final consistencyScore = (ratio * 25).clamp(0, 25);
 
-    final timeScore = (actualSec >= lowerBound && actualSec <= upperBound) ? 25 : 15;
+    final expectedSec = expectedDuration.inSeconds.toDouble();
+    final lowerBound = expectedSec * 0.85;
+    final upperBound = expectedSec * 1.15;
 
-    return min(scriptScore + speedScore + timeScore, 100);
-  }
+    final double timeScore = (totalSec >= lowerBound && totalSec <= upperBound)
+        ? 30.0
+        : 15.0;
 
-  String getGrade(double score) {
-    if (score >= 90) return 'A';
-    if (score >= 80) return 'B';
-    if (score >= 70) return 'C';
-    if (score >= 60) return 'D';
-    return 'F';
+    return (accuracyScore + avgCpmScore + consistencyScore + timeScore).clamp(0, 100);
   }
 }

--- a/app/lib/src/services/practice/script_progress_service.dart
+++ b/app/lib/src/services/practice/script_progress_service.dart
@@ -15,22 +15,25 @@ class ScriptProgressService {
     final recognizedWords = _splitText(recognizedText);
     if (_scriptChunks.isEmpty || recognizedWords.isEmpty) return 0.0;
 
-    int maxMatchedIndex = -1;
+    int scriptIndex = 0;
+    int recognizedIndex = 0;
+    int lastMatchedIndex = -1;
 
-    for (final recognizedWord in recognizedWords) {
-      for (int i = 0; i < _scriptChunks.length; i++) {
-        if (isSimilar(_scriptChunks[i], recognizedWord)) {
-          if (i > maxMatchedIndex) {
-            maxMatchedIndex = i;
-          }
-          break;
-        }
+    while (scriptIndex < _scriptChunks.length &&
+        recognizedIndex < recognizedWords.length) {
+      if (isSimilar(
+        _scriptChunks[scriptIndex],
+        recognizedWords[recognizedIndex],
+      )) {
+        lastMatchedIndex = scriptIndex;
+        recognizedIndex++;
       }
+      scriptIndex++;
     }
 
-    if (maxMatchedIndex == -1) return 0.0;
+    if (lastMatchedIndex == -1) return 0.0;
 
-    return (maxMatchedIndex + 1) / _scriptChunks.length;
+    return (lastMatchedIndex + 1) / _scriptChunks.length;
   }
 
   double calculateAccuracy(String recognizedText) {
@@ -70,7 +73,10 @@ class ScriptProgressService {
     final len1 = s1.length;
     final len2 = s2.length;
 
-    List<List<int>> dp = List.generate(len1 + 1, (_) => List.filled(len2 + 1, 0));
+    List<List<int>> dp = List.generate(
+      len1 + 1,
+      (_) => List.filled(len2 + 1, 0),
+    );
 
     for (int i = 0; i <= len1; i++) {
       for (int j = 0; j <= len2; j++) {
@@ -81,7 +87,13 @@ class ScriptProgressService {
         } else if (s1[i - 1] == s2[j - 1]) {
           dp[i][j] = dp[i - 1][j - 1];
         } else {
-          dp[i][j] = 1 + [dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]].reduce((a, b) => a < b ? a : b);
+          dp[i][j] =
+              1 +
+              [
+                dp[i - 1][j],
+                dp[i][j - 1],
+                dp[i - 1][j - 1],
+              ].reduce((a, b) => a < b ? a : b);
         }
       }
     }

--- a/app/lib/src/services/practice/script_progress_service.dart
+++ b/app/lib/src/services/practice/script_progress_service.dart
@@ -1,0 +1,61 @@
+import 'package:talk_pilot/src/services/database/project_service.dart';
+
+class ScriptProgressService {
+  final ProjectService _projectService = ProjectService();
+
+  List<String> _scriptChunks = [];
+  String _currentRecognizedText = '';
+  double progress = 0.0;
+  List<bool> _matchedFlags = [];
+
+  Future<void> loadScript(String projectId) async {
+    final project = await _projectService.readProject(projectId);
+    final script = project?.script ?? '';
+    _scriptChunks = _splitText(script);
+    _matchedFlags = List.filled(_scriptChunks.length, false);
+  }
+
+  void updateRecognizedText(String recognizedText) {
+    _currentRecognizedText = recognizedText;
+    _matchedFlags = List.filled(_scriptChunks.length, false);
+    progress = _calculateProgress(_currentRecognizedText);
+  }
+
+  double _calculateProgress(String recognizedText) {
+    final recognizedWords = _splitText(recognizedText);
+    if (_scriptChunks.isEmpty) return 0.0;
+
+    for (final word in recognizedWords) {
+      for (int i = 0; i < _scriptChunks.length; i++) {
+        if (!_matchedFlags[i] && isSimilar(_scriptChunks[i], word)) {
+          _matchedFlags[i] = true;
+          break;
+        }
+      }
+    }
+
+    final matchedCount = _matchedFlags.where((v) => v).length;
+    return matchedCount / _scriptChunks.length;
+  }
+
+  List<String> _splitText(String text) {
+    return text
+        .trim()
+        .replaceAll(RegExp(r'[^\uAC00-\uD7A3a-zA-Z0-9\s]'), '')
+        .split(RegExp(r'\s+'))
+        .where((word) => word.isNotEmpty)
+        .toList();
+  }
+
+  bool isSimilar(String a, String b) {
+    return a == b || a.contains(b) || b.contains(a);
+  }
+
+  double getProgress() => progress;
+
+  List<String> get scriptChunks => _scriptChunks;
+
+  List<String> getRecognizedWords() => _splitText(_currentRecognizedText);
+
+  bool isMatchedAt(int index) => index < _matchedFlags.length && _matchedFlags[index];
+}

--- a/app/lib/src/services/practice/script_progress_service.dart
+++ b/app/lib/src/services/practice/script_progress_service.dart
@@ -33,6 +33,20 @@ class ScriptProgressService {
     return (maxMatchedIndex + 1) / _scriptChunks.length;
   }
 
+  double calculateAccuracy(String recognizedText) {
+    final recognizedWords = _splitText(recognizedText);
+    if (recognizedWords.isEmpty) return 0.0;
+
+    int matched = 0;
+    for (final word in recognizedWords) {
+      if (_scriptChunks.any((chunk) => isSimilar(chunk, word))) {
+        matched++;
+      }
+    }
+
+    return matched / recognizedWords.length;
+  }
+
   bool isSimilar(String a, String b) {
     return _similarity(a, b) >= 0.5;
   }

--- a/app/lib/src/services/practice/script_progress_service.dart
+++ b/app/lib/src/services/practice/script_progress_service.dart
@@ -15,44 +15,45 @@ class ScriptProgressService {
     final recognizedWords = _splitText(recognizedText);
     if (_scriptChunks.isEmpty || recognizedWords.isEmpty) return 0.0;
 
-    int scriptIndex = 0;
-    int recognizedIndex = 0;
-    int lastMatchedIndex = -1;
+    int maxMatchedIndex = -1;
+    final matchedScriptIndexes = <int>{};
 
-    while (scriptIndex < _scriptChunks.length &&
-        recognizedIndex < recognizedWords.length) {
-      if (isSimilar(
-        _scriptChunks[scriptIndex],
-        recognizedWords[recognizedIndex],
-      )) {
-        lastMatchedIndex = scriptIndex;
-        recognizedIndex++;
+    for (final recognizedWord in recognizedWords) {
+      for (int i = 0; i < _scriptChunks.length; i++) {
+        if (matchedScriptIndexes.contains(i)) continue;
+
+        if (isSimilar(_scriptChunks[i], recognizedWord)) {
+          matchedScriptIndexes.add(i);
+          if (i > maxMatchedIndex) {
+            maxMatchedIndex = i;
+          }
+          break;
+        }
       }
-      scriptIndex++;
     }
 
-    if (lastMatchedIndex == -1) return 0.0;
+    if (maxMatchedIndex == -1) return 0.0;
 
-    return (lastMatchedIndex + 1) / _scriptChunks.length;
+    return (maxMatchedIndex + 1) / _scriptChunks.length;
   }
 
   double calculateAccuracy(String recognizedText) {
     final recognizedWords = _splitText(recognizedText);
     if (recognizedWords.isEmpty || _scriptChunks.isEmpty) return 0.0;
 
+    final usedScriptIndexes = <int>{};
     int matched = 0;
-    int scriptIndex = 0;
 
     for (final word in recognizedWords) {
-      while (scriptIndex < _scriptChunks.length) {
-        if (isSimilar(_scriptChunks[scriptIndex], word)) {
+      for (int i = 0; i < _scriptChunks.length; i++) {
+        if (usedScriptIndexes.contains(i)) continue;
+
+        if (isSimilar(_scriptChunks[i], word)) {
+          usedScriptIndexes.add(i);
           matched++;
-          scriptIndex++;
           break;
         }
-        scriptIndex++;
       }
-      if (scriptIndex >= _scriptChunks.length) break;
     }
 
     return matched / recognizedWords.length;

--- a/app/lib/src/services/practice/script_progress_service.dart
+++ b/app/lib/src/services/practice/script_progress_service.dart
@@ -35,13 +35,21 @@ class ScriptProgressService {
 
   double calculateAccuracy(String recognizedText) {
     final recognizedWords = _splitText(recognizedText);
-    if (recognizedWords.isEmpty) return 0.0;
+    if (recognizedWords.isEmpty || _scriptChunks.isEmpty) return 0.0;
 
     int matched = 0;
+    int scriptIndex = 0;
+
     for (final word in recognizedWords) {
-      if (_scriptChunks.any((chunk) => isSimilar(chunk, word))) {
-        matched++;
+      while (scriptIndex < _scriptChunks.length) {
+        if (isSimilar(_scriptChunks[scriptIndex], word)) {
+          matched++;
+          scriptIndex++;
+          break;
+        }
+        scriptIndex++;
       }
+      if (scriptIndex >= _scriptChunks.length) break;
     }
 
     return matched / recognizedWords.length;

--- a/app/lib/src/services/practice/script_progress_service.dart
+++ b/app/lib/src/services/practice/script_progress_service.dart
@@ -15,41 +15,51 @@ class ScriptProgressService {
     final recognizedWords = _splitText(recognizedText);
     if (_scriptChunks.isEmpty || recognizedWords.isEmpty) return 0.0;
 
-    int maxMatchedIndex = -1;
+    int lastMatchedScriptIndex = -1;
     final matchedScriptIndexes = <int>{};
 
-    for (final recognizedWord in recognizedWords) {
-      for (int i = 0; i < _scriptChunks.length; i++) {
-        if (matchedScriptIndexes.contains(i)) continue;
+    for (int i = 0; i < recognizedWords.length; i++) {
+      final recognizedWord = recognizedWords[i];
 
-        if (isSimilar(_scriptChunks[i], recognizedWord)) {
-          matchedScriptIndexes.add(i);
-          if (i > maxMatchedIndex) {
-            maxMatchedIndex = i;
+      int start = (i - 10).clamp(0, _scriptChunks.length);
+      int end = (i + 10).clamp(0, _scriptChunks.length);
+
+      for (int j = start; j < end; j++) {
+        if (matchedScriptIndexes.contains(j)) continue;
+
+        if (isSimilar(_scriptChunks[j], recognizedWord)) {
+          matchedScriptIndexes.add(j);
+          if (j > lastMatchedScriptIndex) {
+            lastMatchedScriptIndex = j;
           }
           break;
         }
       }
     }
 
-    if (maxMatchedIndex == -1) return 0.0;
+    if (lastMatchedScriptIndex == -1) return 0.0;
 
-    return (maxMatchedIndex + 1) / _scriptChunks.length;
+    return (lastMatchedScriptIndex + 1) / _scriptChunks.length;
   }
 
   double calculateAccuracy(String recognizedText) {
     final recognizedWords = _splitText(recognizedText);
     if (recognizedWords.isEmpty || _scriptChunks.isEmpty) return 0.0;
 
-    final usedScriptIndexes = <int>{};
+    final matchedScriptIndexes = <int>{};
     int matched = 0;
 
-    for (final word in recognizedWords) {
-      for (int i = 0; i < _scriptChunks.length; i++) {
-        if (usedScriptIndexes.contains(i)) continue;
+    for (int i = 0; i < recognizedWords.length; i++) {
+      final word = recognizedWords[i];
 
-        if (isSimilar(_scriptChunks[i], word)) {
-          usedScriptIndexes.add(i);
+      int start = (i - 10).clamp(0, _scriptChunks.length);
+      int end = (i + 10).clamp(0, _scriptChunks.length);
+
+      for (int j = start; j < end; j++) {
+        if (matchedScriptIndexes.contains(j)) continue;
+
+        if (isSimilar(_scriptChunks[j], word)) {
+          matchedScriptIndexes.add(j);
           matched++;
           break;
         }

--- a/app/lib/src/services/practice/script_progress_service.dart
+++ b/app/lib/src/services/practice/script_progress_service.dart
@@ -33,6 +33,40 @@ class ScriptProgressService {
     return (maxMatchedIndex + 1) / _scriptChunks.length;
   }
 
+  bool isSimilar(String a, String b) {
+    return _similarity(a, b) >= 0.5;
+  }
+
+  double _similarity(String a, String b) {
+    int distance = _levenshtein(a.toLowerCase(), b.toLowerCase());
+    int maxLength = a.length > b.length ? a.length : b.length;
+    if (maxLength == 0) return 1.0;
+    return 1.0 - (distance / maxLength);
+  }
+
+  int _levenshtein(String s1, String s2) {
+    final len1 = s1.length;
+    final len2 = s2.length;
+
+    List<List<int>> dp = List.generate(len1 + 1, (_) => List.filled(len2 + 1, 0));
+
+    for (int i = 0; i <= len1; i++) {
+      for (int j = 0; j <= len2; j++) {
+        if (i == 0) {
+          dp[i][j] = j;
+        } else if (j == 0) {
+          dp[i][j] = i;
+        } else if (s1[i - 1] == s2[j - 1]) {
+          dp[i][j] = dp[i - 1][j - 1];
+        } else {
+          dp[i][j] = 1 + [dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]].reduce((a, b) => a < b ? a : b);
+        }
+      }
+    }
+
+    return dp[len1][len2];
+  }
+
   List<String> _splitText(String text) {
     return text
         .trim()
@@ -40,10 +74,6 @@ class ScriptProgressService {
         .split(RegExp(r'\s+'))
         .where((word) => word.isNotEmpty)
         .toList();
-  }
-
-  bool isSimilar(String a, String b) {
-    return a == b || a.contains(b) || b.contains(a);
   }
 
   List<String> get scriptChunks => _scriptChunks;

--- a/app/lib/src/services/practice/script_progress_service.dart
+++ b/app/lib/src/services/practice/script_progress_service.dart
@@ -66,7 +66,7 @@ class ScriptProgressService {
       }
     }
 
-    return matched / recognizedWords.length;
+    return matched / matchedScriptIndexes.length;
   }
 
   bool isSimilar(String a, String b) {


### PR DESCRIPTION
## 주요 기능
- **STT 음성 입력 기반 발표 연습 기능 구현**
- **사용자의 발표 속도(CPM) 측정 및 시각화**
- **진행도, 정확도, 말 속도 등 실시간 피드백 제공**
- **발표 종료 후 결과 리포트 페이지 구성 및 이동 흐름 구현**

## 세부 구현 사항
- **STT 서비스 연동**
  - 기존에 구현된 STT 음성 인식 서비스 연동
  - 실시간으로 사용자의 발표 내용을 텍스트로 변환

- **발표 연습 기능**
  - `project_detail_page`에서 발표 연습 버튼을 통해 진입 가능
  - 프로젝트에 CPM 데이터가 없을 경우, CPM 측정 페이지로 이동하도록 다이얼로그 표시
  - 단어 인식은 STT를 이용하였으며, Levenshtein Algorithm을 이용함

- **진행 상황 시각화**
  - 원고 기준으로 올바르게 인식된 단어를 하이라이트 처리
  - 전체 진행도 및 인식 정확도 표시
  - 현재 말하는 속도(CPM)를 실시간으로 화면에 표시

- **결과 리포트 페이지**
  - 총 발표 시간, 평균 CPM, 인식 정확도 등 종합 결과 표시
  - 총점을 계산하고 자신의 `targetScore`와 비교하여 표시
  - 발표 진행도가 90% 이상일 경우, 결과 리포트 페이지로 이동 가능한 버튼 제공
  - 리포트 페이지에서 결과 확인 후 `work_page`로 돌아갈 수 있는 버튼 추가

## 고려사항 및 향후 개선점
- STT 인식률은 사용자 발음에 따라 달라질 수 있으며 오차 가능성 존재
- 현재의 STT는 패키지를 이용하는 방식이며, 이는 중간에 말이 멈춘 경우 다시 인식 받을 수 없는 치명적인 오류 발생
  - 따라서 Google Cloud STT를 이용하여 STT를 다시 구현 예정
  - 현재, 구현해둔 기능은 유지하되, STT기능만 Google Cloud STT로 변경 
  - 또한, 현재 영어는 잘 인식되지 않는데 이러한 부분도 Google Cloud STT를 사용하면 더욱 정확한 측정이 가능할 것으로 예상

## 기타
- 시연을 위한 존재하는 데이터를 활용해 로컬 테스트 완료
  - 테스트한 모든 상황에서 로직상의 오류는 없이 작동하였음
  - 정확도 측면에서는 조금 아쉬운 결과를 보이기도 했는데, 이는 STT를 이용하기 때문에 감안해야 할 부분이라고 생각함

## 관련 이슈
Closes #72 