### PR TITLE
[Web] 자동 로그인 시 Nest 서버 인증 수행 로직 추가

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,11 +1,30 @@
-// src/App.jsx
+import Router from './Router';
+import { useEffect } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from './Contexts/AuthContext';
 import { UserProvider } from './Contexts/UserContext';
 import { ProjectProvider } from './Contexts/ProjectContext';
-import Router from './Router';
+
+import { serverLogin } from "./utils/auth/auth";
+import { getAuth, onAuthStateChanged } from "firebase/auth";
 
 function App() {
+  useEffect(() => {
+    const unsub = onAuthStateChanged(getAuth(), async (user) => {
+      if (user) {
+        console.log("[Firebase] 로그인 세션 복원됨 (자동 로그인)");
+        try {
+          const idToken = await user.getIdToken();
+          await serverLogin(idToken);
+        } catch (error) {
+          console.error("[Nest] 자동 로그인 후 서버 인증 실패", error);
+        }
+      }
+    });
+
+    return () => unsub();
+  }, []);
+
   return (
     <BrowserRouter>
       <AuthProvider>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,4 +1,3 @@
-/* 기본 Reset 스타일 */
 * {
     margin: 0;
     padding: 0;

--- a/server/src/stt/stt.gateway.ts
+++ b/server/src/stt/stt.gateway.ts
@@ -39,6 +39,7 @@ export class SttGateway implements OnGatewayConnection, OnGatewayDisconnect {
             const decoded = await admin.auth().verifyIdToken(idToken);
             socket.data.user = decoded;
             console.log(`소켓 연결된 사용자: ${decoded.uid}`);
+            console.log(`소켓 연결됨: ${socket.id}`);
         } catch (err) {
             console.warn(`토큰 인증 실패: ${err.message}`);
             socket.disconnect();


### PR DESCRIPTION
## 해결 사항
Firebase의 `onAuthStateChanged()`를 통해 자동 로그인된 경우, Nest 서버 인증(`/me`) 요청이 누락되어 서버 측에서 사용자 정보가 확인되지 않는 문제를 해결함.

해당 문제는 #94 참고

---

## 변경 사항

- `App.jsx`에서 `onAuthStateChanged()`를 통해 로그인 복원 시 `getIdToken()`을 호출하여 Nest 서버 인증 (`serverLogin(idToken)`) 로직 추가
- 수동 로그인(Google/Kakao) 시에는 기존 로직 유지
- firebase 자동 로그인과 nest 서버 자동 인증 관련 로그 출력

---

## 테스트 화면

![image](https://github.com/user-attachments/assets/009cc5ce-4fd1-48d2-9fce-6334375fbd7c)

---

## 관련 이슈

Closes #94 