### PR TITLE
[App] 프로젝트를 생성할 시, `projectIds`가 덮어씌워지는 에러 해결

### DIFF
--- a/app/lib/src/pages/work_page/widgets/project_action_dialog.dart
+++ b/app/lib/src/pages/work_page/widgets/project_action_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'package:talk_pilot/src/models/user_model.dart';
 import 'package:talk_pilot/src/provider/user_provider.dart';
 import 'package:talk_pilot/src/provider/project_provider.dart';
 import 'package:talk_pilot/src/components/toast_message.dart';
@@ -41,16 +42,24 @@ class _ProjectActionDialogState extends State<_ProjectActionDialog> {
   Future<void> _handleCreate() async {
     final title = titleController.text.trim();
     final desc = descriptionController.text.trim();
-    final user = context.read<UserProvider>().currentUser;
+    final userProvider = context.read<UserProvider>();
     final projectProvider = context.read<ProjectProvider>();
+    final user = userProvider.currentUser;
 
     if (user == null || title.isEmpty) return;
 
-    await projectProvider.createProject(
+    final newProject = await projectProvider.createProject(
       title: title,
       description: desc,
       currentUser: user,
     );
+
+    final mergedProjectIds = {
+      ...?user.projectIds,
+      newProject.id: newProject.status,
+    };
+
+    await userProvider.updateUser({UserField.projectIds: mergedProjectIds});
 
     ToastMessage.show(
       '프로젝트가 생성되었습니다.',

--- a/app/lib/src/provider/project_provider.dart
+++ b/app/lib/src/provider/project_provider.dart
@@ -41,7 +41,7 @@ class ProjectProvider with ChangeNotifier {
   }
 
   /// 프로젝트 생성
-  Future<void> createProject({
+  Future<ProjectModel> createProject({
     required String title,
     required String description,
     required UserModel currentUser,
@@ -68,6 +68,7 @@ class ProjectProvider with ChangeNotifier {
     _projects.insert(0, newProject);
     _selectedProject = newProject;
     notifyListeners();
+    return newProject;
   }
 
   /// 프로젝트 새로고침


### PR DESCRIPTION
제가 좀 힘들고 바쁘고 해서 pr 좀 대충 쓸게요...;;
이번 pr은 확인하는 대로 assign하고 테스트 해보고 merge 바로 부탁드려요.
참고로 이거 문제인지 모르고 DB 초기화 시켰습니다...;;

## 변동 사항

- `project_provider`의 `createProject()`에서 `newProejct`를 return함.
- 위에서 return한 `newProject`를 이용하여 project의 id와 status를 받음.
- `user_service`로 기존에 있던 `projectIds`에 위에서 받은 새 프로젝트 정보를 병합.
- 그렇게 병합된 것을 update하여 해결함.

## 테스트 결과

- 간단하게 테스트 몇번 해봄
- 잘 작동함

## 관련 이슈

Closes #125 