### PR TITLE
[App] 발표 기록 페이지 구현

### DIFF
--- a/app/lib/src/pages/profile_page/cpm_calculate_page.dart
+++ b/app/lib/src/pages/profile_page/cpm_calculate_page.dart
@@ -22,7 +22,6 @@ class _CpmCalculateView extends StatelessWidget {
     final service = context.watch<CpmCalculateService>();
 
     return Scaffold(
-      backgroundColor: const Color(0xFFF5F6FA),
       appBar: AppBar(
         backgroundColor: Colors.deepPurple,
         iconTheme: const IconThemeData(color: Colors.white),

--- a/app/lib/src/pages/profile_page/presentation_history_page.dart
+++ b/app/lib/src/pages/profile_page/presentation_history_page.dart
@@ -63,6 +63,39 @@ class _PresentationHistoryPageState extends State<PresentationHistoryPage> {
     }
   }
 
+  Future<void> _deleteSingleRecord(CpmRecordModel record) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('기록 삭제'),
+        content: const Text('이 발표 기록을 삭제하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('삭제'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm == true) {
+      final uid = FirebaseAuth.instance.currentUser?.uid;
+      if (uid != null) {
+        await _userService.deleteCpmRecord(uid, record.timestamp.millisecondsSinceEpoch);
+        setState(() {
+          _cpmHistoryFuture = _userService.getCpmHistory(uid);
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('기록이 삭제되었습니다')),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -105,6 +138,11 @@ class _PresentationHistoryPageState extends State<PresentationHistoryPage> {
                 subtitle: Text(
                   '${record.timestamp.toLocal()}'.split('.').first,
                   style: const TextStyle(fontSize: 12),
+                ),
+                trailing: IconButton(
+                  icon: const Icon(Icons.delete),
+                  tooltip: '기록 삭제',
+                  onPressed: () => _deleteSingleRecord(record),
                 ),
               );
             },

--- a/app/lib/src/pages/profile_page/presentation_history_page.dart
+++ b/app/lib/src/pages/profile_page/presentation_history_page.dart
@@ -1,7 +1,30 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:talk_pilot/src/models/cpm_record_model.dart';
+import 'package:talk_pilot/src/services/database/cpm_history_service.dart';
+import 'package:talk_pilot/src/services/database/user_service.dart';
 
-class PresentationHistoryPage extends StatelessWidget {
+class PresentationHistoryPage extends StatefulWidget {
   const PresentationHistoryPage({super.key});
+
+  @override
+  State<PresentationHistoryPage> createState() => _PresentationHistoryPageState();
+}
+
+class _PresentationHistoryPageState extends State<PresentationHistoryPage> {
+  final _userService = UserService();
+  late Future<List<CpmRecordModel>> _cpmHistoryFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid != null) {
+      _cpmHistoryFuture = _userService.getCpmHistory(uid);
+    } else {
+      _cpmHistoryFuture = Future.value([]);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -11,12 +34,37 @@ class PresentationHistoryPage extends StatelessWidget {
         iconTheme: const IconThemeData(color: Colors.white),
         title: const Text('발표 기록 확인', style: TextStyle(color: Colors.white)),
       ),
-      body: const Center(
-        child: Text(
-          '발표 기록 확인 페이지는 현재 개발 중입니다.',
-          style: TextStyle(fontSize: 18),
-          textAlign: TextAlign.center,
-        ),
+      body: FutureBuilder<List<CpmRecordModel>>(
+        future: _cpmHistoryFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return const Center(child: Text('데이터를 불러오는 데 실패했습니다.'));
+          }
+          final records = snapshot.data ?? [];
+          if (records.isEmpty) {
+            return const Center(child: Text('CPM 기록이 없습니다.'));
+          }
+          records.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+
+          return ListView.separated(
+            itemCount: records.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final record = records[index];
+              return ListTile(
+                leading: const Icon(Icons.speed),
+                title: Text('${record.cpm.toStringAsFixed(2)} CPM'),
+                subtitle: Text(
+                  '${record.timestamp.toLocal()}'.split('.').first,
+                  style: const TextStyle(fontSize: 12),
+                ),
+              );
+            },
+          );
+        },
       ),
     );
   }

--- a/app/lib/src/pages/profile_page/profile_page.dart
+++ b/app/lib/src/pages/profile_page/profile_page.dart
@@ -7,7 +7,6 @@ import 'package:talk_pilot/src/pages/profile_page/widgets/stats_summary_card.dar
 import 'package:talk_pilot/src/provider/user_provider.dart';
 import 'package:talk_pilot/src/components/toast_message.dart';
 
-import 'package:talk_pilot/src/pages/profile_page/cpm_calculate_page.dart';
 import 'package:talk_pilot/src/pages/profile_page/widgets/profile_card.dart';
 import 'package:talk_pilot/src/pages/profile_page/widgets/profile_drawer.dart';
 
@@ -125,33 +124,6 @@ class _ProfilePageState extends State<ProfilePage> {
               ),
               style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.deepPurple,
-                minimumSize: const Size.fromHeight(50),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-              ),
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton.icon(
-              onPressed: () async {
-                final result = await Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const CpmCalculatePage(),
-                  ),
-                );
-
-                if (result != null && result is double) {
-                  await context.read<UserProvider>().refreshUser();
-                }
-              },
-              icon: const Icon(Icons.calculate, color: Colors.white),
-              label: const Text(
-                'CPM 계산 페이지',
-                style: TextStyle(color: Colors.white),
-              ),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.indigo,
                 minimumSize: const Size.fromHeight(50),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12),

--- a/app/lib/src/services/database/cpm_history_service.dart
+++ b/app/lib/src/services/database/cpm_history_service.dart
@@ -30,4 +30,10 @@ extension CpmHistoryService on UserService {
     await _cpmDb.deleteDB("users/$uid/cpmHistory");
     await updateUser(uid, {'cpm': 0.0});
   }
+
+  Future<void> deleteCpmRecord(String uid, int timestampMillis) async {
+    final recordId = timestampMillis.toString();
+    await _cpmDb.deleteDB("users/$uid/cpmHistory/$recordId");
+    await updateAverageCpm(uid);
+  }
 }

--- a/app/lib/src/services/database/cpm_history_service.dart
+++ b/app/lib/src/services/database/cpm_history_service.dart
@@ -25,4 +25,9 @@ extension CpmHistoryService on UserService {
         history.map((e) => e.cpm).reduce((a, b) => a + b) / history.length;
     await updateUser(uid, {'cpm': avg});
   }
+
+  Future<void> clearCpmHistory(String uid) async {
+    await _cpmDb.deleteDB("users/$uid/cpmHistory");
+    await updateUser(uid, {'cpm': 0.0});
+  }
 }


### PR DESCRIPTION
## 작업 내용
- 발표 기록 페이지 구현
  - cpm과 타임스태프를 보여줌
  - 각각의 기록에 대해 삭제 기능 추가
  - 전체 삭제 기능 추가
  - 삭제 시 평균 cpm 재 계산
 - cpm 측정 페이지 이동 버튼 삭제
   - cpm이 0일 때 자동으로 이동하기 때문에 버튼을 필요 없음

## 테스트 요구 사항
- 발표 기록 페이지의 디자인이 괜찮은지
- 삭제 기능이 잘 작동하는지
- 삭제 후 유저의 CPM이 올바르게 변화하는지

## 관련 이슈
Closes #132 